### PR TITLE
[SIMP-2489] unable to drop a custom rsyslog config

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -155,9 +155,8 @@ class simp_rsyslog::server(
   assert_private()
 
   if $server_conf {
-    rsyslog::rule::local { '0_default':
-      rule            => $server_conf,
-      stop_processing => $stop_processing
+    rsyslog::rule::drop { '0_default':
+      rule => $server_conf
     }
   }
   else {


### PR DESCRIPTION
simp_rsyslog::server uses rsyslog::rule::local instead of rsyslog::rule::drop for custom config

From email thread:



All,

DISCLAIMER: Untested assertions below.

Putting this out here before creating a ticket. I attempted to specify a custom rsyslog config today on an old SIMP 4.2 server and it bombed with this error:

Error 400 on SERVER: "" is not an absolute path. at /etc/puppet/environments/production/modules/rsyslog/manifests/rule/local.pp:80

It seems that the old simp::rsyslog::stock::log_server class calls the rsyslog::rule::local class without either the dyna_file or target_log_file parameters set... which fails the following logic:

if empty($dyna_file)
{ validate_absolute_path($target_log_file) }

Unfortunately, it seems that this logic persists in the current code on GitHub:

SNIPPET: simp_rsyslog::server

if $server_conf {
rsyslog::rule::local
{ '0_default': rule => $server_conf, stop_processing => $stop_processing }

}

SNIPPET: rsyslog::rule::local

if !($dyna_file or $target_log_file)
{ fail('You must specify one of $dyna_file or $target_log_file') }

Can someone confirm that this bug exists? If so, I can create a ticket if that's preferable.

Thanks!

-Nick

Hi Nick,

This is confirmed.

In simp_rsyslog::server, this should be:

rsyslog::rule::drop
{ '0_default': rule => $server_conf }

If you could file a bug, that would be great!

Thanks,

Trevor