### PR TITLE
(SIMP-2698) Log looping and Log rotate problems

### DIFF
--- a/manifests/forward.pp
+++ b/manifests/forward.pp
@@ -34,6 +34,11 @@ class simp_rsyslog::forward (
     fail('You must specify $::simp_rsyslog::log_servers when attempting to forward logs')
   }
 
+  if  $::simp_rsyslog::is_server and $::simp_rsyslog::enable_warning {
+      warning("Possible log forwarding loop. Log forwarding is enable on a log server, ${facts['fqdn']}.  Make sure the log server and its aliases are not in the list of log servers, ${::simp_rsyslog::log_servers}, or fail over servers, ${::simp_rsyslog::failover_log_servers}.  To disable this message set ::simp_rsyslog::enable_warning to false for this server.")
+  }
+
+
   rsyslog::rule::remote { "${order}_simp_rsyslog_profile_remote":
     rule                 => $::simp_rsyslog::security_relevant_logs,
     dest                 => $::simp_rsyslog::log_servers,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,6 +100,11 @@
 #     you are collecting all entries. Otherwise, you run a high risk of
 #     overwhelming your filesystem.
 #
+# @param enable_warning
+#   By default it will log a warning if a log server is set to forward logs.
+#   This can cause a loop unless the simp_rsyslog::servers list does not
+#   contain the log server itself.
+#
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class simp_rsyslog (
@@ -126,7 +131,8 @@ class simp_rsyslog (
   Boolean                     $log_openldap         = false,
   Boolean                     $log_local            = true,
   Stdlib::Absolutepath        $local_target         = '/var/log/secure',
-  Boolean                     $collect_everything   = false
+  Boolean                     $collect_everything   = false,
+  Boolean                     $enable_warning       = true,
 ) {
 
   if $log_openldap {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -160,7 +160,9 @@ class simp_rsyslog::server(
     }
   }
   else {
-    $file_base = '/var/log/hosts/%HOSTNAME%'
+    $logdir ='/var/log/hosts'
+    $file_base = "${logdir}/%HOSTNAME%"
+
 
     # Up front because they are the fastest to process
     if $process_boot_rules {
@@ -323,7 +325,7 @@ class simp_rsyslog::server(
       }
 
       logrotate::rule { 'simp_rsyslog_server_profile':
-        log_files     => [ "${file_base}/*/*.log" ],
+        log_files     => [ "${logdir}/*/*.log" ],
         missingok     => true,
         size          => $rotate_size,
         rotate_period => $rotate_period,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -86,7 +86,7 @@ describe 'simp_rsyslog' do
           it { is_expected.to contain_class('logrotate') }
           it { 
             if facts[:operatingsystemmajrelease].to_s <= '6'
-               expected_cmd ='/usr/sbin/service rsyslog restart > /dev/null 2>&1 || true'
+               expected_cmd ='/sbin/service rsyslog restart > /dev/null 2>&1 || true'
             else
                expected_cmd ='/usr/sbin/systemctl restart rsyslog > /dev/null 2>&1 || true'
             end


### PR DESCRIPTION
  -added warning if possible log looping is detected.
  -fixed directory for log rotate of central log server
  -updated spec tests

SIMP-2699 #close
SIMP-2698 #close
SIMP-2712 #close