### PR TITLE
(SIMP-3166) audit logs not forwarded to rsyslog server

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -12,11 +12,8 @@ fixtures:
     logrotate: 'https://github.com/simp/pupmod-simp-logrotate.git'
     pki:       'https://github.com/simp/pupmod-simp-pki.git'
     rsyslog:
-#FIXME  Once SIMP-3268 is merged, point back to master
-#      repo:   'https://github.com/simp/pupmod-simp-rsyslog.git'
-#      branch: 'master'
-      repo:   'https://github.com/lnemsick-simp/pupmod-simp-rsyslog.git'
-      branch: 'SIMP-3268'
+      repo:   'https://github.com/simp/pupmod-simp-rsyslog.git'
+      branch: 'master'
     simpcat:   'https://github.com/simp/pupmod-simp-simpcat.git'
     simplib:   'https://github.com/simp/pupmod-simp-simplib.git'
     stdlib:    'https://github.com/simp/puppetlabs-stdlib.git'

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -11,7 +11,12 @@ fixtures:
     iptables:  'https://github.com/simp/pupmod-simp-iptables.git'
     logrotate: 'https://github.com/simp/pupmod-simp-logrotate.git'
     pki:       'https://github.com/simp/pupmod-simp-pki.git'
-    rsyslog:   'https://github.com/simp/pupmod-simp-rsyslog.git'
+    rsyslog:
+#FIXME  Once SIMP-3268 is merged, point back to master
+#      repo:   'https://github.com/simp/pupmod-simp-rsyslog.git'
+#      branch: 'master'
+      repo:   'https://github.com/lnemsick-simp/pupmod-simp-rsyslog.git'
+      branch: 'SIMP-3268'
     simpcat:   'https://github.com/simp/pupmod-simp-simpcat.git'
     simplib:   'https://github.com/simp/pupmod-simp-simplib.git'
     stdlib:    'https://github.com/simp/puppetlabs-stdlib.git'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,16 @@
+* Wed May 24 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 0.1.0
+- Fix bug whereby audit logs were not being forwarded to remote syslog servers. 
+- Fix bugs whereby simp_rsyslog::log_collection and simp_rsyslog::log_openldap
+  parameters were overriding simp_rsyslog::default_logs instead of being merged.
+- Work around rsyslog inconsistent message parsing behavior that prevented
+  iptables logs from being written to iptables.log and/or being forwarded,
+  for some versions of rsyslog.
+- Ensure local audispd log messages are not duplicated.
+- Adjust local rule ordering to ensure local sudosh and apache (httpd)
+  log messages are written to their own log files.
+- Restore writing of local puppet and puppet-server messages to their
+  own files, by adjusting local security rsyslog rule from simp_rsyslog::local.
+
 * Wed Apr 19 2017 Nick Markowski <nmarkowski@keywcorp.com> - 0.0.4-0
 - Updated logrotate to use new lastaction API
 

--- a/lib/puppet/functions/simp_rsyslog/merge_hash_of_arrays.rb
+++ b/lib/puppet/functions/simp_rsyslog/merge_hash_of_arrays.rb
@@ -1,0 +1,36 @@
+# Merges a hash of arrays
+#
+Puppet::Functions.create_function(:'simp_rsyslog::merge_hash_of_arrays') do
+  # @param first_hash
+  #   First hash to be merged.  Must be a Hash of Arrays.
+  #
+  # @param additional_hashes
+  #   1 more more additional hashes to be merged.  Each must be a Hash
+  #   of Arrays.
+  #
+  # @return Hash
+  #   Hash containing the superset of keys found in all parameters
+  #   and merged Array values
+  #
+  dispatch :merge_hash_of_arrays do
+    required_param          'Hash', :first_hash
+    required_repeated_param 'Hash', :additional_hashes_to_merge
+  end
+
+  def merge_hash_of_arrays(first_hash, *additional_hashes)
+    require 'deep_merge'
+    validate(first_hash)
+    merged_hash = first_hash.dup
+    additional_hashes.each do |hash|
+      validate(hash)
+      merged_hash.deep_merge!(hash)
+    end
+    return merged_hash
+  end
+
+  def validate(hash)
+    hash.each do |tag,value|
+      fail("'#{hash}' is not a Hash of Arrays") unless value.is_a?(Array)
+    end
+  end
+end

--- a/manifests/forward.pp
+++ b/manifests/forward.pp
@@ -31,7 +31,7 @@ class simp_rsyslog::forward (
   assert_private()
 
   if empty($::simp_rsyslog::log_servers) {
-    fail('You must specify $::simp_rsyslog::log_servers when attempting to forward logs')
+    fail('You must specify ::simp_rsyslog::log_servers when attempting to forward logs')
   }
 
   if  $::simp_rsyslog::is_server and $::simp_rsyslog::enable_warning {

--- a/manifests/local.pp
+++ b/manifests/local.pp
@@ -5,19 +5,47 @@
 # @param order
 #   The shell-glob-based ordering for the rule
 #
-#   * This is currently set to not interfere with dynamic local rules and to
-#     come before the standard 'ZZ' local SIMP default rules with some room to
-#     grow.
+#   This is currently set to ensure the following:
+#   * Comes after the dynamic local rules that would be on a Rsyslog server
+#     (1* and 3* rules from simp_rsyslog::server)
+#   * Comes after the SIMP-module-specific rules that would be on a Rsyslog 
+#     client (XX_* and YY_* rules from the sudosh, apache etc. modules).
+#   * Comes before the standard 'ZZ_default.conf' file from SIMP's rsyslog
+#     module. 
 #
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class simp_rsyslog::local (
-  String $order = 'HH'
+  String $order = 'ZZ_0'
 ){
   assert_private()
 
-  rsyslog::rule::local { "${order}_simp_rsyslog_profile_local":
-    rule            => $::simp_rsyslog::security_relevant_logs,
+  # Since there already are local audispd audit logs in /var/log/audit and these
+  # logs grow quickly, drop the syslog duplicates.
+  rsyslog::rule::local { "${order}1_simp_rsyslog_profile_local_drop_audispd_duplicates":
+    rule       => '$programname == \'audispd\'',
+    dyna_file  => '~',
+    # We don't need this due to the line above
+    stop_processing => true
+  }
+
+  # All other security logs which will NOT be handled by the 'ZZ_default' rules.
+  # (ZZ_default contains iptables, puppet-agent, puppetserver and
+  # local6.* rules, in the appropriate order.)
+  #
+  # TODO 
+  # 1. Write a rule that allows *.emerg messages to both log to the console
+  #    of all users and to be persisted to file.
+  # 2. Remove sudosh from this rule, since it is already represented in a rule
+  #    from the SIMP sudosh module.
+  $_residual_logs = {
+    'programs'   => [ 'sudo', 'sudosh', 'audit', 'auditd', 'yum', 'systemd', 'crond' ],
+    'facilities' => [ 'local7.warn', '*.emerg'],
+  }
+
+  $residual_security_logs = simp_rsyslog::format_options($_residual_logs)
+  rsyslog::rule::local { "${order}2_simp_rsyslog_profile_local_security":
+    rule            => $residual_security_logs,
     target_log_file => $::simp_rsyslog::local_target,
     stop_processing => true
   }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -172,13 +172,6 @@ class simp_rsyslog::server(
         stop_processing => $stop_processing
       }
     }
-    if $process_kern_rules {
-      rsyslog::rule::local { '10_00_default_kern':
-        rule            => 'prifilt(\'kern.*\')',
-        dyna_file       => "${file_base}/kernel.log",
-        stop_processing => $stop_processing
-      }
-    }
     if $process_mail_rules {
       rsyslog::rule::local { '10_00_default_mail':
         rule            => 'prifilt(\'mail.*\')',
@@ -230,12 +223,12 @@ class simp_rsyslog::server(
     }
     if $process_puppet_agent_rules {
       rsyslog::rule::local { '10_default_puppet_agent_error':
-        rule            => 'prifilt(\'*.err\') and ($programname == \'puppet\')',
+        rule            => 'prifilt(\'*.err\') and ($programname == \'puppet-agent\')',
         dyna_file       => "${file_base}/puppet_agent_error.log",
         stop_processing => $stop_processing
       }
       rsyslog::rule::local { '11_default_puppet_agent':
-        rule            => '$programname == \'puppet\'',
+        rule            => '$programname == \'puppet-agent\'',
         dyna_file       => "${file_base}/puppet_agent.log",
         stop_processing => $stop_processing
       }
@@ -254,7 +247,7 @@ class simp_rsyslog::server(
     }
     if $process_auditd_rules {
       rsyslog::rule::local { '10_default_audit':
-        rule            => 'prifilt(\'local5.*\') or ($programname == \'audispd\') or ($syslogtag == \'tag_auditd_log:\')',
+        rule            => '($programname == \'audispd\') or ($syslogtag == \'tag_auditd_log:\')',
         dyna_file       => "${file_base}/auditd.log",
         stop_processing => $stop_processing
       }
@@ -268,8 +261,17 @@ class simp_rsyslog::server(
     }
     if $process_iptables_rules {
       rsyslog::rule::local { '10_default_iptables':
-        rule            => 'prifilt(\'kern.*\') and ($msg startswith \'IPT:\')',
+        # Some versions of rsyslog include the space separator that precedes
+        # the message as part of the message body
+        rule            => 'prifilt(\'kern.*\') and (($msg startswith \' IPT:\') or ($msg startswith \'IPT:\'))',
         dyna_file       => "${file_base}/iptables.log",
+        stop_processing => $stop_processing
+      }
+    }
+    if $process_kern_rules {
+      rsyslog::rule::local { '10_default_kern':
+        rule            => 'prifilt(\'kern.*\')',
+        dyna_file       => "${file_base}/kernel.log",
         stop_processing => $stop_processing
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_rsyslog",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet Profile for standard Rsyslog configurations",
   "license": "Apache-2.0",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,9 +1,7 @@
 HOSTS:
-  server5:
+  el7-server:
     roles:
       - default
-      - master
-      - server
       - rsyslog_server
       - el7
     platform:   el-7-x86_64
@@ -15,10 +13,9 @@ HOSTS:
         gpgkeys:
           - https://getfedora.org/static/352C64E5.txt
 
-  client5:
+  el7-client:
     roles:
-      - client
-      - agent
+      - rsyslog_client
       - el7
     platform:   el-7-x86_64
     box:        centos/7
@@ -29,9 +26,8 @@ HOSTS:
         gpgkeys:
           - https://getfedora.org/static/352C64E5.txt
 
-  server4:
+  el6-server:
     roles:
-      - simp_server
       - rsyslog_server
       - el6
     platform:   el-6-x86_64
@@ -43,10 +39,9 @@ HOSTS:
         gpgkeys:
           - https://getfedora.org/static/0608B895.txt
 
-  client4:
+  el6-client:
     roles:
-      - client
-      - agent
+      - rsyslog_client
       - el6
     platform:   el-6-x86_64
     box:        centos/6

--- a/spec/acceptance/suites/default/00_rsyslog_spec.rb
+++ b/spec/acceptance/suites/default/00_rsyslog_spec.rb
@@ -24,22 +24,124 @@ describe 'simp_rsyslog' do
     EOS
   }
 
-  hosts_with_role(hosts, 'client').each do |host|
-    it 'should configure the system without errors' do
-      apply_manifest_on(host, manifest, :catch_failures => true)
-    end
+  hosts_with_role(hosts, 'rsyslog_client').each do |host|
+    context "local-only logging on #{host.name}" do
+      it 'should configure the system without errors' do
+        apply_manifest_on(host, manifest, :catch_failures => true)
+      end
 
-    it 'should configure the system idempotently' do
-      apply_manifest_on(host, manifest, :catch_changes => true)
-    end
+      it 'should configure the system idempotently' do
+        apply_manifest_on(host, manifest, :catch_changes => true)
+      end
 
-    it 'should collect security relevant log files from local6 into /var/log/secure' do
-      on(host, 'logger -p local6.warn -t test_msg LOGGERSECURECHECK')
-      sleep(1)
+      it 'should drop duplicate audispd log messages' do
+        # log message identified by program name
+        on(host, 'logger -p local5.notice -t audispd LOCAL_ONLY_AUDISPD_DROP')
+        sleep(5)
 
-      check = on(host, 'grep -l LOGGERSECURECHECK /var/log/secure').stdout.strip
+        on(host, 'grep -r LOCAL_ONLY_AUDISPD_DROP /var/log', :acceptable_exit_codes => [1])
+      end
 
-      expect(check).to eq('/var/log/secure')
+      it 'should collect iptables log messages in /var/log/iptables.log' do
+        # kern facility messages cannot be created by a user via logger,
+        # because the facility is automatically changed to user. So, the
+        # only way to test this is to cause an actual iptables drop.
+        # TODO:  The code below should be replaced with use of the actual
+        #   iptables modules, a new drop rule for some port, and then nc
+        #   to try to open a connection to that port.
+        #
+        # Set up iptables to disallow icmp requests
+        on(host, 'iptables --list-rules')
+        on(host, 'iptables -N LOG_AND_DROP')
+        on(host, 'iptables -A LOG_AND_DROP -j LOG --log-prefix "IPT:"')
+        on(host, 'iptables -A LOG_AND_DROP -j DROP')
+        on(host, 'iptables -A INPUT -p icmp -m icmp --icmp-type 8 -j LOG_AND_DROP')
+        on(host, 'ping -c 1 `facter ipaddress`', :accept_all_exit_codes => true)
+        check = on(host, "grep -l 'IPT:' /var/log/iptables.log").stdout.strip
+        expect(check).to eq('/var/log/iptables.log')
+
+        # clean up iptables rules to allow any future tests using the
+        # SIMP iptables module to start with a clean slate
+        on(host, 'iptables --delete LOG_AND_DROP -j LOG --log-prefix "IPT:"')
+        on(host, 'iptables --delete LOG_AND_DROP -j DROP')
+        on(host, 'iptables --delete INPUT -p icmp -m icmp --icmp-type 8 -j LOG_AND_DROP')
+        on(host, 'iptables -X LOG_AND_DROP')
+        on(host, 'iptables --list-rules')
+      end
+
+      it 'should collect other security relevant log messages in /var/log/secure' do
+        # some of the rules come from simp_rsyslog and some from rsyslog
+        # log messages identified by program name
+        on(host, 'logger -t auditd LOCAL_ONLY_AUDITD_LOG')
+        on(host, 'logger -t audit LOCAL_ONLY_AUDIT_LOG')
+        on(host, 'logger -p local2.info -t sudosh LOCAL_ONLY_SUDOSH_LOG')
+        on(host, 'logger -t sudo LOCAL_ONLY_SUDO_LOG')
+        on(host, 'logger -t yum LOCAL_ONLY_YUM_LOG')
+        on(host, 'logger -t systemd LOCAL_ONLY_SYSTEMD_LOG')
+
+        # log messages identified by facility and/or priority
+        on(host, 'logger -t crond LOCAL_ONLY_CROND_LOG')
+        on(host, 'logger -p authpriv.warning -t auth LOCAL_ONLY_AUTHPRIV_ANY_LOG')
+        on(host, 'logger -p local5.notice -t id2 LOCAL_ONLY_LOCAL5_ANY_LOG')
+        on(host, 'logger -p local6.info -t httpd LOCAL_ONLY_LOCAL6_ANY_LOG')
+        on(host, 'logger -p local7.warning -t id3 LOCAL_ONLY_LOCAL7_WARN_LOG')
+        on(host, 'logger -p local4.emerg -t id4 LOCAL_ONLY_ANY_EMERG_LOG')
+
+        wait_for_log_message(host, '/var/log/secure', 'LOCAL_ONLY_ANY_EMERG_LOG')
+
+        [ 'LOCAL_ONLY_AUDITD_LOG',
+          'LOCAL_ONLY_AUDIT_LOG',
+          'LOCAL_ONLY_SUDOSH_LOG',  # sudosh module is not installed so ends up in secure.log
+          'LOCAL_ONLY_SUDO_LOG',
+          'LOCAL_ONLY_YUM_LOG',
+          'LOCAL_ONLY_SYSTEMD_LOG',
+          'LOCAL_ONLY_CROND_LOG',
+          'LOCAL_ONLY_AUTHPRIV_ANY_LOG',
+          'LOCAL_ONLY_LOCAL5_ANY_LOG',
+          'LOCAL_ONLY_LOCAL6_ANY_LOG',
+          'LOCAL_ONLY_LOCAL7_WARN_LOG',
+          'LOCAL_ONLY_ANY_EMERG_LOG',
+        ].each do |message|
+            check = on(host, "grep -l '#{message}' /var/log/secure").stdout.strip
+            expect(check).to eq('/var/log/secure')
+        end
+      end
+
+      it 'should collect puppet-agent log messages in /var/log/puppet-agent*.log' do
+        on(host, 'logger -p local6.err -t puppet-agent LOCAL_ONLY_PUPPET_AGENT_ERR')
+        on(host, 'logger -p local6.notice -t puppet-agent LOCAL_ONLY_PUPPET_AGENT_NOTICE')
+        wait_for_log_message(host, '/var/log/puppet-agent.log', 'LOCAL_ONLY_PUPPET_AGENT_NOTICE')
+
+        check = on(host, 'grep -l LOCAL_ONLY_PUPPET_AGENT_ERR /var/log/puppet-agent-err.log').stdout.strip
+        expect(check).to eq('/var/log/puppet-agent-err.log')
+        check = on(host, 'grep -l LOCAL_ONLY_PUPPET_AGENT_ERR /var/log/puppet-agent.log').stdout.strip
+        expect(check).to eq('/var/log/puppet-agent.log')
+        check = on(host, 'grep -l LOCAL_ONLY_PUPPET_AGENT_NOTICE /var/log/puppet-agent.log').stdout.strip
+        expect(check).to eq('/var/log/puppet-agent.log')
+      end
+
+      it 'should collect puppetserver log messages in /var/log/puppetserver*.log' do
+        on(host, 'logger -p local6.err -t puppetserver LOCAL_ONLY_PUPPET_SERVER_ERR')
+        on(host, 'logger -p local6.notice -t puppetserver LOCAL_ONLY_PUPPET_SERVER_NOTICE')
+        wait_for_log_message(host, '/var/log/puppetserver.log', 'LOCAL_ONLY_PUPPET_SERVER_NOTICE')
+
+        check = on(host, 'grep -l LOCAL_ONLY_PUPPET_SERVER_ERR /var/log/puppetserver-err.log').stdout.strip
+        expect(check).to eq('/var/log/puppetserver-err.log')
+        check = on(host, 'grep -l LOCAL_ONLY_PUPPET_SERVER_ERR /var/log/puppetserver.log').stdout.strip
+        expect(check).to eq('/var/log/puppetserver.log')
+        check = on(host, 'grep -l LOCAL_ONLY_PUPPET_SERVER_NOTICE /var/log/puppetserver.log').stdout.strip
+        expect(check).to eq('/var/log/puppetserver.log')
+      end
+
+      it 'should collect slapd log messages in /var/log/slapd_audit.log' do
+        on(host, 'logger -t slapd_audit LOCAL_ONLY_SLAPD_AUDIT')
+        wait_for_log_message(host, '/var/log/slapd_audit.log', 'LOCAL_ONLY_SLAPD_AUDIT')
+      end
+
+      it 'should collect cron log messages in /var/log/cron' do
+        on(host, 'logger -p cron.warning -t cron LOCAL_ONLY_CRON_ANY_LOG')
+        wait_for_log_message(host, '/var/log/cron', 'LOCAL_ONLY_CRON_ANY_LOG')
+      end
     end
   end
 end

--- a/spec/acceptance/suites/default/04_rsyslog_server_spec.rb
+++ b/spec/acceptance/suites/default/04_rsyslog_server_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper_acceptance'
 
 test_name 'simp_rsyslog profile'
 
+
 describe 'simp_rsyslog' do
   before(:context) do
     hosts.each do |host|
@@ -18,8 +19,6 @@ describe 'simp_rsyslog' do
     end
   end
 
-  let(:servers) { hosts_with_role( hosts, 'rsyslog_server' ) }
-
   let(:server_manifest) {
     <<-EOS
       include 'simp_rsyslog'
@@ -28,223 +27,93 @@ describe 'simp_rsyslog' do
   let(:server_hieradata) {
     <<-EOS
 ---
-rsyslog::pki: false
 simp_rsyslog::is_server: true
+simp_rsyslog::forward_logs: false
+rsyslog::tcp_server: true
+rsyslog::tls_tcp_server: false
+rsyslog::pki: false
     EOS
 }
 
-let(:server_disable01_hieradata) {
-    <<-EOS
-#{server_hieradata}
-simp_rsyslog::server::process_sudosh_rules: false
-simp_rsyslog::server::process_httpd_rules: false
-simp_rsyslog::server::process_dcpd_rules: false
-simp_rsyslog::server::process_puppet_agent_rules: false
-simp_rsyslog::server::process_puppetserver_rules: false
-simp_rsyslog::server::process_auditd_rules: false
-simp_rsyslog::server::process_slapd_rules: false
-simp_rsyslog::server::process_kern_rules: false
-simp_rsyslog::server::process_iptables_rules: false
-simp_rsyslog::server::process_message_rules: false
-simp_rsyslog::server::process_mail_rules: false
-simp_rsyslog::server::process_cron_rules: false
-simp_rsyslog::server::process_emerg_rules: false
-simp_rsyslog::server::process_spool_rules: false
-simp_rsyslog::server::process_boot_rules: false
-    EOS
-  }
+  hosts_with_role( hosts, 'rsyslog_server' ).each do |server|
+    context "#{server} logging to the co-resident syslog server" do
+      let(:log_dir) { "/var/log/hosts/#{fact_on(server,'fqdn')}" }
 
-  let(:server_disable017_hieradata) {
-    <<-EOS
-#{server_hieradata}
-simp_rsyslog::server::process_sudosh_rules: false
-simp_rsyslog::server::process_httpd_rules: false
-simp_rsyslog::server::process_dcpd_rules: false
-simp_rsyslog::server::process_puppet_agent_rules: false
-simp_rsyslog::server::process_puppetserver_rules: false
-simp_rsyslog::server::process_auditd_rules: false
-simp_rsyslog::server::process_slapd_rules: false
-simp_rsyslog::server::process_kern_rules: false
-simp_rsyslog::server::process_iptables_rules: false
-simp_rsyslog::server::process_message_rules: true
-simp_rsyslog::server::process_mail_rules: false
-simp_rsyslog::server::process_cron_rules: false
-simp_rsyslog::server::process_emerg_rules: false
-simp_rsyslog::server::process_spool_rules: false
-simp_rsyslog::server::process_boot_rules: false
-simp_rsyslog::server::process_security_relevant_logs: false
-    EOS
-  }
-
-  # Test simp_rsyslog::server
-  #
-  #
-  context 'with is_server = true' do
-    it 'should configure the server without errors' do
-      servers.each do |server|
+      it 'should configure the server without errors' do
         set_hieradata_on(server, server_hieradata)
         apply_manifest_on(server, server_manifest, :catch_failures => true)
       end
-    end
-    it 'should configure the servers idempotently' do
-      servers.each do |server|
+
+      it 'should configure the servers idempotently' do
         apply_manifest_on(server, server_manifest, :catch_changes => true)
       end
-    end
 
-    # Log Server Test1: Ensure syslog messages are processed by their
-    # intended rule(s), and that there are no re-processed messages (duplicates).
-    #
-    # Log_servers uses a 3 tier log-local rule hierarchy:
-    #   0/1 - facility specific logs
-    #   7   - secure.log (security relevant logs)
-    #   9   - messages.log
-    #
-    # Each takes precedence over the next.  For instance, if a
-    # 7 rule encompasses a 0/1 rule, the 0/1 rule should process the log message
-    # first, then stop processing such that the 7 or 9 rule will not process it.
-    #
-    # This testing scheme iterates over every 0/1 rule in server.pp, and
-    # ensures it is not re-processed by 7/9 rules.  7 rules encompassed by 9 rules
-    # are tested as well.
-    #
-    #
-    it 'testing default server rules' do
-      servers.each do |server|
-        # 0/1 rules
-        # 
-        on server, "logger -t sudosh LOGGERSUDOSH"
-        on server, "logger -p local0.warn -t httpd LOGGERHTTPDNOERR"
-        on server, "logger -p local0.err -t httpd LOGGERHTTPDERR"
-        on server, "logger -t dhcpd LOGGERDHCP"
-        on server, "logger -p local0.err -t puppet LOGGERPUPPETAGENTERR"
-        on server, "logger -p local0.warn -t puppet LOGGERPUPPETAGENTNOERR"
-        on server, "logger -p local0.err -t puppetserver LOGGERPUPPETMASTERERR"
-        on server, "logger -p local0.warn -t puppetserver LOGGERPUPPETMASTERNOERR"
-        # NOTE: on server, "logger -t audispd LOGGERAUDISPD * does not work!"
-        on server, "logger -t audispd LOGGERTAGAUDITLOG"
-        on server, "logger -t slapd_audit LOGGERSLAPDAUDIT"
-        # NOTE: on server, "IPT does not work!" see logger man page for
-        # potential kern issues
-        on server, "logger -p mail.warn -t mail LOGGERMAIL"
-        on server, "logger -p cron.warn -t cron LOGGERCRON"
-        # TODO: test console output for emerge
-        on server, "logger -p cron.emerg -t cron LOGGEREMERG"
-        on server, "logger -p news.crit -t news LOGGERNEWS"
-        on server, "logger -p uucp.warn -t uucp LOGGERUUCP"
-        on server, "logger -p local7.warn -t boot LOGGERBOOT"
-        # 7 rules
-        #
-        on server, "logger -t yum LOGGERYUM"
-        on server, "logger -p authpriv.warn -t auth LOGGERAUTHPRIV"
-        on server, "logger -p local5.warn -t local5 LOGGERLOCAL5"
-        on server, "logger -p local6.warn -t local6 LOGGERLOCAL6"
-        # 9 rules
-        #
-        on server, "logger -p local0.info -t info LOGGERINFO"
+      it 'should collect iptables messages to host-specific iptables.log' do
+        # Set up iptables to disallow icmp requests
+        on(server, 'iptables --list-rules')
+        on(server, 'iptables -N LOG_AND_DROP')
+        on(server, 'iptables -A LOG_AND_DROP -j LOG --log-prefix "IPT:"')
+        on(server, 'iptables -A LOG_AND_DROP -j DROP')
+        on(server, 'iptables -A INPUT -p icmp -m icmp --icmp-type 8 -j LOG_AND_DROP')
+        on(server, 'ping -c 1 `facter ipaddress`', :accept_all_exit_codes => true)
+        result = on(server, "grep -l 'IPT:' #{log_dir}/iptables.log")
+        expect(result.stdout.strip).to eq("#{log_dir}/iptables.log")
 
-        # This array maps each tag's message, above, to its template file (log file).
-        test_array = [
-          ["LOGGERSUDOSH", "sudosh.log"],
-          ["LOGGERHTTPDNOERR", "httpd.log"],
-          ["LOGGERHTTPDERR", "httpd_error.log"],
-          ["LOGGERDHCP", "dhcpd.log"],
-          ["LOGGERPUPPETAGENTERR", "puppet_agent_error.log"],
-          ["LOGGERPUPPETAGENTNOERR", "puppet_agent.log"],
-          ["LOGGERPUPPETMASTERERR", "puppetserver_error.log"],
-          ["LOGGERPUPPETMASTERNOERR", "puppetserver.log"],
-          ["LOGGERTAGAUDITLOG", "auditd.log"],
-          ["LOGGERLOCAL5", "auditd.log"],
-          ["LOGGERSLAPDAUDIT", "slapd_audit.log"],
-          ["LOGGERMAIL", "mail.log"],
-          ["LOGGERCRON", "cron.log"],
-          ["LOGGEREMERG", "cron.log"],
-          ["LOGGERNEWS", "spool.log"],
-          ["LOGGERUUCP", "spool.log"],
-          ["LOGGERBOOT", "boot.log"],
-          ["LOGGERYUM", "secure.log"],
-          ["LOGGERAUTHPRIV", "secure.log"],
-          ["LOGGERLOCAL6", "secure.log"],
-          ["LOGGERINFO", "messages.log"]]
+        # clean up iptables rules to allow any future tests using the
+        # SIMP iptables module to start with a clean slate
+        on(server, 'iptables --delete LOG_AND_DROP -j LOG --log-prefix "IPT:"')
+        on(server, 'iptables --delete LOG_AND_DROP -j DROP')
+        on(server, 'iptables --delete INPUT -p icmp -m icmp --icmp-type 8 -j LOG_AND_DROP')
+        on(server, 'iptables -X LOG_AND_DROP')
+        on(server, 'iptables --list-rules')
+      end
 
-        result_dir = "/var/log/hosts/#{fact_on(server,'fqdn')}"
+      it 'should collect messages to host-specific files' do
+        # Each entry in this array is [log_options, log_message, log_file]
+        default_test_array = [
+          ['-p local7.warning -t boot',   'LOCAL_SERVER_BOOT_LOG',         'boot.log'],
+          ['-p mail.info -t id1',         'LOCAL_SERVER_ANY_MAIL_LOG',     'mail.log'],
+          ['-p cron.warning -t cron',     'LOCAL_SERVER_CRON_ANY_LOG',     'cron.log'],
+          ['-p local4.emerg -t id2',      'LOCAL_SERVER_ANY_EMERG_LOG',    'emergency.log'],
+          ['-p local2.info -t sudosh',    'LOCAL_SERVER_SUDOSH_LOG',       'sudosh.log'],
+          ['-p local6.err -t httpd',      'LOCAL_SERVER_HTTPD_ERR_LOG',    'httpd_error.log'],
+          ['-p local6.warn -t httpd',     'LOCAL_SERVER_HTTPD_NO_ERR_LOG', 'httpd.log'],
+          ['-t dhcpd',                    'LOCAL_SERVER_DHCPD_LOG',        'dhcpd.log'],
+          ['-p local6.err -t puppet-agent',     'LOCAL_SERVER_PUPPET_AGENT_ERR_LOG',    'puppet_agent_error.log'],
+          ['-p local6.warning -t puppet-agent', 'LOCAL_SERVER_PUPPET_AGENT_NO_ERR_LOG', 'puppet_agent.log'],
+          ['-p local6.err -t puppetserver',     'LOCAL_SERVER_PUPPETSERVER_ERR_LOG',    'puppetserver_error.log'],
+          ['-p local6.warning -t puppetserver', 'LOCAL_SERVER_PUPPETSERVER_NO_ERR_LOG', 'puppetserver.log'],
+          ['-p local5.notice -t audispd', 'LOCAL_SERVER_AUDISPD_LOG',      'auditd.log'],
+          ['-t slapd_audit',              'LOCAL_SERVER_SLAPD_AUDIT_LOG',  'slapd_audit.log'],
+          ['-p news.crit -t news',        'LOCAL_SERVER_NEWS_CRIT_LOG',    'spool.log'],
+          ['-p uucp.crit -t uucp',        'LOCAL_SERVER_UUCP_CRIT_LOG',    'spool.log'],
+          ['-t auditd',                   'LOCAL_SERVER_AUDITD_LOG',       'secure.log'],
+          ['-t audit',                    'LOCAL_SERVER_AUDIT_LOG',        'secure.log'],
+          ['-t sudo',                     'LOCAL_SERVER_SUDO_LOG',         'secure.log'],
+          ['-t yum',                      'LOCAL_SERVER_YUM_LOG',          'secure.log'],
+          ['-t systemd',                  'LOCAL_SERVER_SYSTEMD_LOG',      'secure.log'],
+          ['-t crond',                    'LOCAL_SERVER_CROND_LOG',        'secure.log'],
+          ['-p authpriv.warning -t auth', 'LOCAL_SERVER_AUTHPRIV_ANY_LOG', 'secure.log'],
+          ['-p local6.info -t id3',       'LOCAL_SERVER_LOCAL6_ANY_LOG',   'secure.log']
+        ]
+
+        # send the messages
+        default_test_array.each do |options,message,logfile|
+          on(server,"logger #{options} #{message}")
+        end
+
+        wait_for_log_message(server, File.join(log_dir, default_test_array[-1][2]),
+          default_test_array[-1][1])
 
         # Ensure each message ended up in the intended log.
-        test_array.each do |message|
-          result = on server, "grep -Rl #{message[0]} #{result_dir}"
-          expect(result.stdout.strip).to eq("#{result_dir}/#{message[1]}")
+        default_test_array.each do |options,message,logfile|
+          result = on(server, "grep -Rl #{message} #{log_dir}")
+          expect(result.stdout.strip).to eq("#{log_dir}/#{logfile}")
         end
       end
-    end
 
-    # Log Server Test2: Disable all 0/1 stop rules and test 7/9 rules.
-    #
-    #
-    it 'should disable 0/1 rules' do
-      servers.each do |server|
-        set_hieradata_on(server, server_disable01_hieradata)
-        apply_manifest_on(server, server_manifest, :catch_failures => true)
-      end
-    end
-    it 'testing server with 0/1 stop rules disabled' do
-      servers.each do |server|
-        on server, "logger -t sudosh LOGGERSUDOSHSECURE"
-        on server, "logger -t yum LOGGERYUMSECURE"
-        on server, "logger -p cron.warn -t cron LOGGERCRONWARNSECURE"
-        on server, "logger -p authpriv.warn -t auth LOGGERAUTHPRIVSECURE"
-        on server, "logger -p local5.warn -t local5 LOGGERLOCAL5SECURE"
-        on server, "logger -p local6.warn -t local6 LOGGERLOCAL6SECURE"
-        on server, "logger -p local7.warn -t boot BOOTSECURE"
-        on server, "logger -p cron.emerg -t cron LOGGEREMERGSECURE"
-        # NOTE: on server, "IPT does not work!" see logger man page for
-        # potential kern issues
-
-        test_array = ["LOGGERSUDOSHSECURE","LOGGERYUMSECURE",
-                      "LOGGERCRONWARNSECURE", "LOGGERAUTHPRIVSECURE",
-                      "LOGGERLOCAL6SECURE",
-                      "BOOTSECURE", "LOGGEREMERGSECURE"]
-        result_dir = "/var/log/hosts/#{fact_on(server,'fqdn')}"
-
-        test_array.each do |message|
-          result = on server, "grep -Rl #{message} #{result_dir}"
-          expect(result.stdout.strip).to eq("#{result_dir}/secure.log")
-        end
-      end
-    end
-
-    # Log Server Test3: Disable all 0/1/7 stop rules and test 9 rules.
-    #
-    #
-    it 'should disable 0/1/7 rules' do
-      servers.each do |server|
-        set_hieradata_on(server, server_disable017_hieradata)
-        apply_manifest_on(server, server_manifest, :catch_failures => true)
-      end
-    end
-    it 'testing server with 0/1/7 stop rules disabled' do
-      servers.each do |server|
-        on server, "logger -p local0.info -t local0 LOGGERLOCAL0MESSAGES"
-        on server, "logger -p mail.warn -t mail LOGGERMAILNONEMESSAGES"
-        on server, "logger -p authpriv.warn -t authpriv LOGGERAUTHPRIVNONEMESSAGES"
-        on server, "logger -p cron.warn -t cron LOGGERCRONNONEMESSAGES"
-        on server, "logger -p local6.warn -t local6 LOGGERLOCAL6NONEMESSAGES"
-        on server, "logger -p local5.warn -t local5 LOGGERLOCAL5NONEMESSAGES"
-
-        test_array = ["LOGGERMAILNONEMESSAGES", "LOGGERAUTHPRIVNONEMESSAGES",
-                      "LOGGERCRONNONEMESSAGES", "LOGGERLOCAL6NONEMESSAGES",
-                      "LOGGERLOCAL5NONEMESSAGES"]
-        result_dir = "/var/log/hosts/#{fact_on(server,'fqdn')}"
-
-        # *.info should be logged
-        result = on server, "grep -Rl LOGGERLOCAL0MESSAGES #{result_dir}"
-        expect(result.stdout.strip).to eq("#{result_dir}/messages.log")
-
-        # Catchall should have grabbed the rest
-        test_array.each do |message|
-          result = on server, "grep -Rl #{message} #{result_dir}"
-          expect(result.stdout.strip).to eq("#{result_dir}/catchall.log")
-        end
-      end
+      pending 'it should catch any unexpected messages'
+      pending 'it should drop other messages'
     end
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,72 +1,184 @@
 require 'spec_helper'
 
-file_content_7 = "/usr/bin/systemctl restart rsyslog > /dev/null 2>&1 || true"
-file_content_6 = "/sbin/service rsyslog restart > /dev/null 2>&1 || true"
+file_content_7 = '/usr/bin/systemctl restart rsyslog > /dev/null 2>&1 || true'
+file_content_6 = '/sbin/service rsyslog restart > /dev/null 2>&1 || true'
 
 describe 'simp_rsyslog' do
-  shared_examples_for "a structured module" do
+  shared_examples_for 'a structured module' do
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_class('simp_rsyslog') }
   end
 
-  context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
-      context "on #{os}" do
-        let(:facts) do
-          facts
-        end
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
 
-        context "simp_rsyslog class without any parameters" do
-          let(:params) {{ }}
-          it_behaves_like "a structured module"
-          it { is_expected.to contain_class('simp_rsyslog::local') }
-          it {
-            is_expected.to contain_rsyslog__rule__local('HH_simp_rsyslog_profile_local').with_rule(
-              /\(\$programname == 'sudo'\) or \(\$programname == 'sudosh'\)/
-            )
-          }
-          it { is_expected.to contain_rsyslog__rule__local('HH_simp_rsyslog_profile_local').with_stop_processing(true) }
-          it { is_expected.not_to contain_class('simp_rsyslog::server') }
-          it { is_expected.not_to contain_class('simp_rsyslog::forward') }
-        end
+      let(:program_logs) do
+        [ "($programname == 'sudo')",
+          "($programname == 'sudosh')",
+          "($programname == 'yum')",
+          "($programname == 'audispd')",
+          "($programname == 'auditd')",
+          "($programname == 'audit')",
+          "($programname == 'systemd')",
+          "($programname == 'crond')",
+        ]
+      end
 
-        context "simp rsyslog class collecting all logs" do
-          let(:params){{
-            :collect_everything => true
-          }}
+      let(:facility_logs) do
+        [ "prifilt('cron.*')",
+          "prifilt('authpriv.*')",
+          "prifilt('local6.*')",
+          "prifilt('local7.warn')",
+          "prifilt('*.emerg')",
+        ]
+      end
 
-          it_behaves_like "a structured module"
-          it { is_expected.to contain_class('simp_rsyslog::local') }
-          it { is_expected.to contain_rsyslog__rule__local('HH_simp_rsyslog_profile_local').with_rule("prifilt('*.*')") }
-          it { is_expected.to contain_rsyslog__rule__local('HH_simp_rsyslog_profile_local').with_stop_processing(true) }
-          it { is_expected.not_to contain_class('simp_rsyslog::server') }
-          it { is_expected.not_to contain_class('simp_rsyslog::forward') }
-        end
+      let(:msg_starts_logs) do
+        [ "($msg startswith ' IPT:')",
+          "($msg startswith 'IPT:')"
+        ]
+      end
 
-        context "simp_rsyslog class forwarding logs" do
+      let(:default_security_relevant_logs) do
+        (program_logs + facility_logs + msg_starts_logs).join(' or ')
+      end
+
+      let (:residual_security_logs) do
+        [ "($programname == 'sudo')",
+          "($programname == 'sudosh')",
+          "($programname == 'audit')",
+          "($programname == 'auditd')",
+          "($programname == 'yum')",
+          "($programname == 'systemd')",
+          "($programname == 'crond')",
+          "prifilt('local7.warn')",
+          "prifilt('*.emerg')"
+        ].join(' or ')
+      end
+
+      context 'simp_rsyslog class with default parameters' do
+        let(:params) {{ }}
+        it_behaves_like 'a structured module'
+        it { is_expected.to contain_class('simp_rsyslog::local') }
+        it { is_expected.to contain_rsyslog__rule__local('ZZ_01_simp_rsyslog_profile_local_drop_audispd_duplicates') }
+        it {
+          is_expected.to contain_rsyslog__rule__local('ZZ_02_simp_rsyslog_profile_local_security').with_rule(
+            Regexp.new(Regexp.escape(residual_security_logs))
+          )
+        }
+        it { is_expected.to contain_rsyslog__rule__local('ZZ_02_simp_rsyslog_profile_local_security').with_stop_processing(true) }
+        it { is_expected.not_to contain_class('simp_rsyslog::server') }
+        it { is_expected.not_to contain_class('simp_rsyslog::forward') }
+      end
+
+      context 'simp rsyslog class that enables forwarding' do
+        context 'forwarding default logs' do
           let(:params) {{
             :forward_logs => true,
             :log_servers  => ['1.2.3.4']
           }}
-          it_behaves_like "a structured module"
+
+          it_behaves_like 'a structured module'
+          it { is_expected.to contain_class('simp_rsyslog::local') }
           it { is_expected.to contain_class('simp_rsyslog::forward') }
           it {
-            is_expected.to contain_rsyslog__rule__remote('99_simp_rsyslog_profile_remote').with_rule(
-              /\(\$programname == 'sudo'\) or \(\$programname == 'sudosh'\)/
+            is_expected.to contain_rsyslog__rule__remote('99_simp_rsyslog_profile_remote').with(
+             {
+              :rule                 => Regexp.new(Regexp.escape(default_security_relevant_logs)),
+              :dest                 => ['1.2.3.4'],
+              :failover_log_servers => [],
+              :dest_type            => 'tcp',
+              :stop_processing      => false
+             }
             )
           }
-          it { is_expected.to contain_rsyslog__rule__remote('99_simp_rsyslog_profile_remote').with_dest_type('tcp') }
-          it { is_expected.to contain_rsyslog__rule__remote('99_simp_rsyslog_profile_remote').with_stop_processing(false) }
+          it { is_expected.not_to contain_class('simp_rsyslog::server') }
         end
 
-        context "simp_rsyslog class log server" do
+        context 'forwarding all logs but disable local rsyslog configuration' do
+          let(:params){{
+            :forward_logs         => true,
+            :log_servers          => ['1.2.3.4'],
+            :failover_log_servers => ['3.4.5.6'],
+            :collect_everything   => true,
+            :log_local            => false
+          }}
+
+          it_behaves_like 'a structured module'
+          it { is_expected.to contain_class('simp_rsyslog::forward') }
+          it {
+            is_expected.to contain_rsyslog__rule__remote('99_simp_rsyslog_profile_remote').with(
+             {
+              :rule                 => "prifilt('*.*')",
+              :dest                 => ['1.2.3.4'],
+              :failover_log_servers => ['3.4.5.6'],
+              :dest_type            => 'tcp',
+              :stop_processing      => false
+             }
+            )
+          }
+          it { is_expected.not_to contain_class('simp_rsyslog::local') }
+          it { is_expected.not_to contain_class('simp_rsyslog::server') }
+        end
+
+        context 'with openldap log forwarding enabled' do
+          let(:params) {{
+            :forward_logs => true,
+            :log_servers  => ['1.2.3.4'],
+            :log_openldap => true
+          }}
+  
+          it_behaves_like 'a structured module'
+          it {
+            logs = program_logs + [ "($programname == 'slapd')" ] +
+              facility_logs + [ "prifilt('local4.*')" ] + msg_starts_logs
+            expected_logs = logs.join(' or ')
+            is_expected.to contain_rsyslog__rule__remote('99_simp_rsyslog_profile_remote').with_rule(
+              Regexp.new(Regexp.escape(expected_logs))
+            )
+          }
+        end
+  
+        context 'custom log forwarding' do
+          let(:params) {{
+            :forward_logs => true,
+            :log_servers  => ['1.2.3.4'],
+            :log_collection => {
+              'facilities' => ['local2.warn']
+             }
+          }}
+  
+          it_behaves_like 'a structured module'
+          it {
+            logs = program_logs + facility_logs + [ "prifilt('local2.warn')" ] +
+              msg_starts_logs
+            expected_logs = logs.join(' or ')
+            is_expected.to contain_rsyslog__rule__remote('99_simp_rsyslog_profile_remote').with_rule(
+              Regexp.new(Regexp.escape(expected_logs))
+            )
+          }
+        end
+
+        context 'with remote log servers not specified' do
+          let(:params) {{
+            :forward_logs => true,
+            :log_servers  => [],
+          }}
+          it { is_expected.not_to compile.with_all_deps }
+        end
+      end
+
+      context 'simp_rsyslog class that is a log server' do
+        context 'with default parameters' do
           let(:params) {{
             :is_server => true
           }}
-          it_behaves_like "a structured module"
+          it_behaves_like 'a structured module'
           it { is_expected.to contain_class('simp_rsyslog::server') }
           it { is_expected.to contain_rsyslog__rule__local('10_00_default_boot') }
-          it { is_expected.to contain_rsyslog__rule__local('10_00_default_kern') }
           it { is_expected.to contain_rsyslog__rule__local('10_00_default_mail') }
           it { is_expected.to contain_rsyslog__rule__local('10_00_default_cron') }
           it { is_expected.to contain_rsyslog__rule__local('10_00_default_emerg') }
@@ -81,8 +193,11 @@ describe 'simp_rsyslog' do
           it { is_expected.to contain_rsyslog__rule__local('10_default_audit') }
           it { is_expected.to contain_rsyslog__rule__local('10_default_slapd_audit') }
           it { is_expected.to contain_rsyslog__rule__local('10_default_iptables') }
+          it { is_expected.to contain_rsyslog__rule__local('10_default_kern') }
           it { is_expected.to contain_rsyslog__rule__local('10_default_spool') }
-          it { is_expected.to contain_rsyslog__rule__local('17_default_security_relevant_logs') }
+          it { is_expected.to contain_rsyslog__rule__local('17_default_security_relevant_logs').with_rule(
+              Regexp.new(Regexp.escape(default_security_relevant_logs))
+          ) }
           it { is_expected.to contain_rsyslog__rule__local('19_default_message') }
           it { is_expected.to contain_rsyslog__rule__local('30_default_catchall') }
           it { is_expected.not_to contain_rsyslog__rule__local('30_default_drop') }
@@ -96,18 +211,69 @@ describe 'simp_rsyslog' do
           end
         end
 
-        context "simp_rsyslog class with everything enabled" do
+        context 'simp_rsyslog class that is a log server with all features disabled' do
+          # no reason to disable all, but this allows testing of individual disable
+          # parameters
           let(:params) {{
-            :is_server            => true,
-            :forward_logs         => true,
-            :log_servers          => ['1.2.3.4'],
-            :failover_log_servers => ['3.4.5.6'],
-            :log_openldap         => true,
-            :collect_everything   => true
+            :is_server => true
           }}
-
-          it_behaves_like "a structured module"
+          let(:hieradata) { 'rsyslog_server_features_disabled' }
+          it_behaves_like 'a structured module'
           it { is_expected.to contain_class('simp_rsyslog::server') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_00_default_boot') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_00_default_mail') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_00_default_cron') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_00_default_emerg') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_sudosh') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_httpd_error') }
+          it { is_expected.not_to contain_rsyslog__rule__local('11_default_httpd') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_dhcpd') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_puppet_agent_error') }
+          it { is_expected.not_to contain_rsyslog__rule__local('11_default_puppet_agent') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_puppetserver_error') }
+          it { is_expected.not_to contain_rsyslog__rule__local('11_default_puppetserver') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_audit') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_slapd_audit') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_iptables') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_kern') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_spool') }
+          it { is_expected.not_to contain_rsyslog__rule__local('17_default_security_relevant_logs') }
+          it { is_expected.not_to contain_rsyslog__rule__local('19_default_message') }
+          it { is_expected.not_to contain_rsyslog__rule__local('30_default_catchall') }
+          it { is_expected.not_to contain_rsyslog__rule__local('30_default_drop') }
+          it { is_expected.not_to contain_logrotate__rule('simp_rsyslog_server_profile') }
+        end
+
+        context 'simp_rsyslog class that is a log server with custom rules' do
+          let(:params) {{
+            :is_server => true
+          }}
+          let(:hieradata) { 'rsyslog_server_custom_rules' }
+          it_behaves_like 'a structured module'
+          it { is_expected.to contain_class('simp_rsyslog::server') }
+          it { is_expected.to contain_rsyslog__rule__drop('0_default').with_rule('prifilt(\'*.*\')') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_00_default_boot') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_00_default_mail') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_00_default_cron') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_00_default_emerg') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_sudosh') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_httpd_error') }
+          it { is_expected.not_to contain_rsyslog__rule__local('11_default_httpd') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_dhcpd') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_puppet_agent_error') }
+          it { is_expected.not_to contain_rsyslog__rule__local('11_default_puppet_agent') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_puppetserver_error') }
+          it { is_expected.not_to contain_rsyslog__rule__local('11_default_puppetserver') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_audit') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_slapd_audit') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_iptables') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_kern') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_spool') }
+          it { is_expected.not_to contain_rsyslog__rule__local('17_default_security_relevant_logs') }
+          it { is_expected.not_to contain_rsyslog__rule__local('19_default_message') }
+          it { is_expected.not_to contain_rsyslog__rule__local('30_default_catchall') }
+          it { is_expected.not_to contain_rsyslog__rule__local('30_default_drop') }
+          it { is_expected.not_to contain_logrotate__rule('simp_rsyslog_server_profile') }
         end
       end
     end

--- a/spec/fixtures/hieradata/rsyslog_server_custom_rules.yaml
+++ b/spec/fixtures/hieradata/rsyslog_server_custom_rules.yaml
@@ -1,0 +1,2 @@
+---
+simp_rsyslog::server::server_conf: "prifilt('*.*')"

--- a/spec/fixtures/hieradata/rsyslog_server_features_disabled.yaml
+++ b/spec/fixtures/hieradata/rsyslog_server_features_disabled.yaml
@@ -1,0 +1,21 @@
+---
+simp_rsyslog::server::process_sudosh_rules: false
+simp_rsyslog::server::process_httpd_rules: false
+simp_rsyslog::server::process_dhcpd_rules: false
+simp_rsyslog::server::process_puppet_agent_rules: false
+simp_rsyslog::server::process_puppetserver_rules: false
+simp_rsyslog::server::process_auditd_rules: false
+simp_rsyslog::server::process_slapd_rules: false
+simp_rsyslog::server::process_kern_rules: false
+simp_rsyslog::server::process_iptables_rules: false
+simp_rsyslog::server::process_security_relevant_logs: false
+simp_rsyslog::server::process_message_rules: false
+simp_rsyslog::server::process_mail_rules: false
+simp_rsyslog::server::process_cron_rules: false
+simp_rsyslog::server::process_emerg_rules: false
+simp_rsyslog::server::process_spool_rules: false
+simp_rsyslog::server::process_boot_rules: false
+simp_rsyslog::server::enable_catchall: false
+simp_rsyslog::server::stop_processing: false
+simp_rsyslog::server::add_logrotate_rule: false
+

--- a/spec/functions/simp_rsyslog/merge_hash_of_arrays_spec.rb
+++ b/spec/functions/simp_rsyslog/merge_hash_of_arrays_spec.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe 'simp_rsyslog::merge_hash_of_arrays' do
+  let (:hash1) { {
+    'programs'   => ['program1', 'program2'],
+    'facilities' => ['facility1'],
+    'msg_starts' => ['start1', 'start2']
+  } }
+
+  let (:hash2) { {
+    'programs'   => ['program2', 'program3'],
+    'msg_starts' => ['start0']
+  } }
+
+  let (:hash3) { {
+    'programs'   => ['program1', 'program4', 'program0'],
+    'facilities' => ['facility3'],
+    'msg_starts' => [],
+    'msg_regex'  => ['msg[0-9]+']
+  } }
+
+  context 'with valid parameters' do
+    it { is_expected.to run.with_params( hash1, {} ).and_return(hash1) }
+    it { is_expected.to run.with_params( {}, hash1 ).and_return(hash1) }
+    it { 
+      is_expected.to run.with_params( hash1, hash2, hash3 ).and_return(
+        {
+          'programs'   => ['program1', 'program2', 'program3', 'program4', 'program0'],
+          'facilities' => ['facility1', 'facility3'],
+          'msg_starts' => ['start1', 'start2', 'start0'],
+          'msg_regex'  => ['msg[0-9]+']
+        }
+      )
+    }
+  end
+
+  context 'with bad parameters' do
+    it {
+      is_expected.to run.with_params({ 'programs' => 'program0'}, hash3 ).and_raise_error(/is not a Hash of Arrays/)
+    }
+
+    it {
+      is_expected.to run.with_params(hash1, { 'programs' => 'program5'} ).and_raise_error(/is not a Hash of Arrays/)
+    }
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -4,6 +4,39 @@ require 'yaml'
 require 'simp/beaker_helpers'
 include Simp::BeakerHelpers
 
+# Wait up to max_wait_seconds for a message to be logged on a host or fail
+# @param [String] host Name of test server on which the log file resides
+# @param [String] log Fully qualified path to log on the test server
+# @param [String] message Message to search for within the test server's log
+# @param [Float]  max_wait_seconds Maximum number of seconds to wait for the
+#                                  message to be found in the log before failing
+# @param [Float]  interval_sec Interval in seconds between log checks
+#
+# TODO move to Simp::BeakerHelpers
+require 'timeout'
+def wait_for_log_message(
+    host,
+    log,
+    message,
+    max_wait_seconds = (ENV['SIMPTEST_WAIT_FOR_LOG_MAX'] ? ENV['SIMPTEST_WAIT_FOR_LOG_MAX'].to_f : 60.0),
+    interval_sec = (ENV['SIMPTEST_LOG_CHECK_INTERVAL'] ? ENV['SIMPTEST_LOG_CHECK_INTERVAL'].to_f : 1.0)
+  )
+  result = nil
+  Timeout::timeout(max_wait_seconds) do
+    while true
+      result = on host, "grep '#{message}' #{log}", :accept_all_exit_codes => true
+      return if result.exit_code == 0
+      sleep(interval_sec)
+    end
+  end
+rescue Timeout::Error => e
+  error_msg = "Failed to find '#{message}' in #{log} on #{host} within #{max_wait_seconds} seconds:\n"
+  error_msg += "\texit_code = #{result.exit_code}\n"
+  error_msg += "\tstdout = \"#{result.stdout}\"\n" unless result.stdout.nil? or result.stdout.strip.empty?
+  error_msg += "\tstderr = \"#{result.stderr}\"" unless result.stderr.nil? or result.stderr.strip.empty?
+  fail error_msg
+end
+
 unless ENV['BEAKER_provision'] == 'no'
   hosts.each do |host|
     # Install Puppet


### PR DESCRIPTION
- Fixed bug whereby audit logs were not being forwarded to remote syslog servers.
- Added tests (that revealed other problems....)

Addressed other bugs/issues found during testing:
- Fixed bugs whereby simp_rsyslog::log_collection and simp_rsyslog::log_openldap
  parameters were overriding simp_rsyslog::default_logs instead of being merged.
- Added a workaround for rsyslog inconsistent message parsing behavior that prevented
  iptables logs from being written to iptables.log and/or being forwarded,
  for some versions of rsyslog.
- Ensured local audispd log messages are not duplicated.
- Adjusted local rule ordering to ensure local sudosh and apache (httpd)
  log messages are written to their own log files.
- Restored writing of local puppet and puppet-server messages to their
  own files, by adjusting local security rsyslog rule from simp_rsyslog::local.