### PR TITLE
(SIMP-3476) simp_rsyslog: Revert bundler version pinning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ cache: bundler
 before_script:
   - bundle update
 bundler_args: --without development system_tests --path .vendor
-before_install:
-  - rm Gemfile.lock || true
-  - rvm @global do gem uninstall bundler -a -x
-  - rvm @global do gem install bundler -v '~> 1.14.0'
+before_install: rm Gemfile.lock || true
 script:
   - bundle exec rake test
 notifications:


### PR DESCRIPTION
Revert bundler version pinning, now that 4.0.1 simp-rake-helpers no
longer requires it. This version pinning was causing gitlab-ci
problems.

SIMP-3476 #close