### PR TITLE
(SIMP-3671) simp_rsyslog: handle aide syslog messages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Sep 06 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 0.2.0-0
+- Add processing for aide logs
+
 * Wed Aug 23 2017 Jeanne Greulich <jeanne.greulich@onypoint.com> - 0.2.0-0
 - added processing for snmpd logs
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,7 +123,7 @@ class simp_rsyslog (
     Array[String]
   ]                           $default_logs         = {
 
-    'programs'   => [ 'sudo', 'sudosh', 'yum', 'audispd', 'auditd', 'audit', 'systemd', 'crond' ],
+    'programs'   => [ 'sudo', 'sudosh', 'yum', 'audispd', 'auditd', 'audit', 'systemd', 'crond', 'snmpd', 'aide' ],
     'facilities' => [ 'cron.*', 'authpriv.*', 'local6.*', 'local7.warn', '*.emerg'],
     # Some versions of rsyslog include the space separator that precedes
     # the message as part of the message body

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -60,6 +60,9 @@
 # @param process_auditd_rules
 #   Enable processing of auditd rules
 #
+# @param process_aide_rules
+#   Enable processing of aide rules
+#
 # @param process_slapd_rules
 #   Enable processing of OpenLDAP Server rules
 #
@@ -136,6 +139,7 @@ class simp_rsyslog::server(
   Boolean                                   $process_puppet_agent_rules     = true,
   Boolean                                   $process_puppetserver_rules     = true,
   Boolean                                   $process_auditd_rules           = true,
+  Boolean                                   $process_aide_rules             = true,
   Boolean                                   $process_slapd_rules            = true,
   Boolean                                   $process_kern_rules             = true,
   Boolean                                   $process_iptables_rules         = true,
@@ -260,6 +264,13 @@ class simp_rsyslog::server(
       rsyslog::rule::local { '10_default_audit':
         rule            => '($programname == \'audispd\') or ($syslogtag == \'tag_auditd_log:\')',
         dyna_file       => "${file_base}/auditd.log",
+        stop_processing => $stop_processing
+      }
+    }
+    if $process_aide_rules {
+      rsyslog::rule::local { '10_default_aide':
+        rule            => '$programname == \'aide\'',
+        dyna_file       => "${file_base}/aide.log",
         stop_processing => $stop_processing
       }
     }

--- a/spec/acceptance/suites/default/04_rsyslog_server_spec.rb
+++ b/spec/acceptance/suites/default/04_rsyslog_server_spec.rb
@@ -80,6 +80,7 @@ rsyslog::pki: false
           ['-p local6.warn -t httpd',     'LOCAL_SERVER_HTTPD_NO_ERR_LOG', 'httpd.log'],
           ['-t dhcpd',                    'LOCAL_SERVER_DHCPD_LOG',        'dhcpd.log'],
           ['-t snmpd',                    'LOCAL_SERVER_SNMPD_LOG',        'snmpd.log'],
+          ['-t aide',                     'LOCAL_SERVER_AIDE_LOG',         'aide.log'],
           ['-p local6.err -t puppet-agent',     'LOCAL_SERVER_PUPPET_AGENT_ERR_LOG',    'puppet_agent_error.log'],
           ['-p local6.warning -t puppet-agent', 'LOCAL_SERVER_PUPPET_AGENT_NO_ERR_LOG', 'puppet_agent.log'],
           ['-p local6.err -t puppetserver',     'LOCAL_SERVER_PUPPETSERVER_ERR_LOG',    'puppetserver_error.log'],

--- a/spec/acceptance/suites/default/05_rsyslog_forward_spec.rb
+++ b/spec/acceptance/suites/default/05_rsyslog_forward_spec.rb
@@ -112,6 +112,7 @@ EOS
             ['-p local6.warning -t httpd',  'CLIENT_FORWARDED_HTTPD_NO_ERR_LOG', 'httpd.log',       'secure'], # local='httpd/access_log' when simp_apache is installed
             ['-t dhcpd',                    'CLIENT_FORWARDED_DHCPD_LOG',        nil,               'messages'], # local='dhcpd' when dhcp is installed
             ['-p local6.info -t snmpd',     'CLIENT_FORWARDED_SNMPD_LOG',        'snmpd.log',       'secure'], # local='snmpd.log' when snmpd is installed
+            ['-p local6.notice -t aide',    'CLIENT_FORWARDED_AIDE_LOG',         'aide.log',        'secure'], # local='aide/aide.log' when aide is installed
             ['-p local6.err -t puppet-agent',     'CLIENT_FORWARDED_PUPPET_AGENT_ERR_LOG',     'puppet_agent_error.log', 'puppet-agent-err.log'],
             ['-p local6.warning -t puppet-agent', 'CLIENT_FORWARDED_PUPPET_AGENT_NO_ERR_LOG',  'puppet_agent.log',       'puppet-agent.log'],
             ['-p local6.err -t puppetserver',     'CLIENT_FORWARDED_PUPPETSERVER_ERR_LOG',     'puppetserver_error.log', 'puppetserver-err.log'],

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -24,6 +24,8 @@ describe 'simp_rsyslog' do
           "($programname == 'audit')",
           "($programname == 'systemd')",
           "($programname == 'crond')",
+          "($programname == 'snmpd')",
+          "($programname == 'aide')"
         ]
       end
 
@@ -192,6 +194,7 @@ describe 'simp_rsyslog' do
           it { is_expected.to contain_rsyslog__rule__local('10_default_puppetserver_error') }
           it { is_expected.to contain_rsyslog__rule__local('11_default_puppetserver') }
           it { is_expected.to contain_rsyslog__rule__local('10_default_audit') }
+          it { is_expected.to contain_rsyslog__rule__local('10_default_aide') }
           it { is_expected.to contain_rsyslog__rule__local('10_default_slapd_audit') }
           it { is_expected.to contain_rsyslog__rule__local('10_default_iptables') }
           it { is_expected.to contain_rsyslog__rule__local('10_default_kern') }
@@ -235,6 +238,7 @@ describe 'simp_rsyslog' do
           it { is_expected.not_to contain_rsyslog__rule__local('10_default_puppetserver_error') }
           it { is_expected.not_to contain_rsyslog__rule__local('11_default_puppetserver') }
           it { is_expected.not_to contain_rsyslog__rule__local('10_default_audit') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_aide') }
           it { is_expected.not_to contain_rsyslog__rule__local('10_default_slapd_audit') }
           it { is_expected.not_to contain_rsyslog__rule__local('10_default_iptables') }
           it { is_expected.not_to contain_rsyslog__rule__local('10_default_kern') }
@@ -268,6 +272,7 @@ describe 'simp_rsyslog' do
           it { is_expected.not_to contain_rsyslog__rule__local('10_default_puppetserver_error') }
           it { is_expected.not_to contain_rsyslog__rule__local('11_default_puppetserver') }
           it { is_expected.not_to contain_rsyslog__rule__local('10_default_audit') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_aide') }
           it { is_expected.not_to contain_rsyslog__rule__local('10_default_slapd_audit') }
           it { is_expected.not_to contain_rsyslog__rule__local('10_default_iptables') }
           it { is_expected.not_to contain_rsyslog__rule__local('10_default_kern') }

--- a/spec/fixtures/hieradata/rsyslog_server_features_disabled.yaml
+++ b/spec/fixtures/hieradata/rsyslog_server_features_disabled.yaml
@@ -6,6 +6,7 @@ simp_rsyslog::server::process_snmpd_rules: false
 simp_rsyslog::server::process_puppet_agent_rules: false
 simp_rsyslog::server::process_puppetserver_rules: false
 simp_rsyslog::server::process_auditd_rules: false
+simp_rsyslog::server::process_aide_rules: false
 simp_rsyslog::server::process_slapd_rules: false
 simp_rsyslog::server::process_kern_rules: false
 simp_rsyslog::server::process_iptables_rules: false


### PR DESCRIPTION
- Makes sure aide and snmpd logs are forwarded to remote syslog
  server via program name, instead of assuming they will be forwarded
  based on syslog facility.
- Persist aide logs on the remote syslog server in its own directory,
  as the logs get large when AIDE is run periodically.