### PR TITLE
(SIMP-5099) Update to support tlog

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,19 +1,19 @@
 ---
 fixtures:
   repositories:
-    auditd: https://github.com/simp/pupmod-simp-auditd.git
+    auditd:    'https://github.com/simp/pupmod-simp-auditd.git'
     augeasproviders_core: https://github.com/simp/augeasproviders_core
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub
-    iptables:  https://github.com/simp/pupmod-simp-iptables.git
-    logrotate: https://github.com/simp/pupmod-simp-logrotate.git
-    pki: https://github.com/simp/pupmod-simp-pki.git
+    iptables:  'https://github.com/simp/pupmod-simp-iptables.git'
+    logrotate: 'https://github.com/simp/pupmod-simp-logrotate.git'
+    pki:       'https://github.com/simp/pupmod-simp-pki.git'
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog.git
-    simpcat: https://github.com/simp/pupmod-simp-simpcat.git
-    simplib: https://github.com/simp/pupmod-simp-simplib.git
-    stdlib: https://github.com/simp/puppetlabs-stdlib.git
+    simpcat:   'https://github.com/simp/pupmod-simp-simpcat.git'
+    simplib:   'https://github.com/simp/pupmod-simp-simplib.git'
+    stdlib:    'https://github.com/simp/puppetlabs-stdlib.git'
     systemd:
-      repo: https://github.com/simp/puppet-systemd
-      branch: simp-master
-    tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers.git
+      repo: 'https://github.com/simp/puppet-systemd.git'
+      branch: 'simp-master'
+    tcpwrappers: 'https://github.com/simp/pupmod-simp-tcpwrappers.git'
   symlinks:
     simp_rsyslog: '#{source_dir}'

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,19 +1,19 @@
 ---
 fixtures:
   repositories:
-    auditd:    'https://github.com/simp/pupmod-simp-auditd.git'
-    augeasproviders_core: https://github.com/simp/augeasproviders_core
-    augeasproviders_grub: https://github.com/simp/augeasproviders_grub
-    iptables:  'https://github.com/simp/pupmod-simp-iptables.git'
-    logrotate: 'https://github.com/simp/pupmod-simp-logrotate.git'
-    pki:       'https://github.com/simp/pupmod-simp-pki.git'
+    auditd: https://github.com/simp/pupmod-simp-auditd.git
+    augeasproviders_core: https://github.com/simp/augeasproviders_core.git
+    augeasproviders_grub: https://github.com/simp/augeasproviders_grub.git
+    iptables: https://github.com/simp/pupmod-simp-iptables.git
+    logrotate: https://github.com/simp/pupmod-simp-logrotate.git
+    pki: https://github.com/simp/pupmod-simp-pki.git
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog.git
-    simpcat:   'https://github.com/simp/pupmod-simp-simpcat.git'
-    simplib:   'https://github.com/simp/pupmod-simp-simplib.git'
-    stdlib:    'https://github.com/simp/puppetlabs-stdlib.git'
+    simpcat: https://github.com/simp/pupmod-simp-simpcat.git
+    simplib: https://github.com/simp/pupmod-simp-simplib.git
+    stdlib: https://github.com/simp/puppetlabs-stdlib.git
     systemd:
-      repo: 'https://github.com/simp/puppet-systemd.git'
-      branch: 'simp-master'
-    tcpwrappers: 'https://github.com/simp/pupmod-simp-tcpwrappers.git'
+      repo: https://github.com/simp/puppet-systemd.git
+      branch: simp-master
+    tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers.git
   symlinks:
-    simp_rsyslog: '#{source_dir}'
+    simp_rsyslog: "#{source_dir}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Mon Aug 27 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.3.0-0
+- Remove redundant rules for sudosh since the puppet module will correctly take
+  care of adding those rules
+- Add support for tlog since it will be commonly replacing sudosh across the
+  SIMP infrastructure
+
 * Thu Jun 14 2018 Nick Miller <nick.miller@onyxpoint.com> - 0.2.1-0
 - Update systemd fixtures and CI assets
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,8 +123,28 @@ class simp_rsyslog (
     Array[String]
   ]                           $default_logs         = {
 
-    'programs'   => [ 'sudo', 'sudosh', 'yum', 'audispd', 'auditd', 'audit', 'systemd', 'crond', 'snmpd', 'aide' ],
-    'facilities' => [ 'cron.*', 'authpriv.*', 'local6.*', 'local7.warn', '*.emerg'],
+    'programs'   => [
+      'aide',
+      'audispd',
+      'audit',
+      'auditd',
+      'crond',
+      'snmpd',
+      'sudo',
+      'sudosh',
+      'systemd',
+      'tlog',
+      'tlog-rec-session',
+      '-tlog-rec-session',
+      'yum'
+    ],
+    'facilities' => [
+      '*.emerg',
+      'authpriv.*',
+      'cron.*',
+      'local6.*',
+      'local7.warn'
+    ],
     # Some versions of rsyslog include the space separator that precedes
     # the message as part of the message body
     'msg_starts' => [' IPT:', 'IPT:'],

--- a/manifests/local.pp
+++ b/manifests/local.pp
@@ -34,11 +34,21 @@ class simp_rsyslog::local (
   # TODO
   # 1. Write a rule that allows *.emerg messages to both log to the console
   #    of all users and to be persisted to file.
-  # 2. Remove sudosh from this rule, since it is already represented in a rule
-  #    from the SIMP sudosh module.
   $_residual_logs = {
-    'programs'   => [ 'sudo', 'sudosh', 'audit', 'auditd', 'yum', 'systemd', 'crond' ],
-    'facilities' => [ 'local7.warn', '*.emerg'],
+    'programs'   => [
+      'audispd',
+      'audit',
+      'auditd',
+      'crond',
+      'sudo',
+      'systemd',
+      'yum'
+    ],
+
+    'facilities' => [
+      '*.emerg',
+      'local7.warn'
+    ],
   }
 
   $residual_security_logs = simp_rsyslog::format_options($_residual_logs)

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -42,6 +42,9 @@
 # @param process_sudosh_rules
 #   Enable processing of sudosh rules
 #
+# @param process_tlog_rules
+#   Enable processing of tlog rules
+#
 # @param process_httpd_rules
 #   Enable processing of httpd rules
 #
@@ -133,6 +136,7 @@
 class simp_rsyslog::server(
   Optional[String]                          $server_conf                    = undef,
   Boolean                                   $process_sudosh_rules           = true,
+  Boolean                                   $process_tlog_rules             = true,
   Boolean                                   $process_httpd_rules            = true,
   Boolean                                   $process_dhcpd_rules            = true,
   Boolean                                   $process_snmpd_rules            = true,
@@ -207,6 +211,13 @@ class simp_rsyslog::server(
       rsyslog::rule::local { '10_default_sudosh':
         rule            => '$programname == \'sudosh\'',
         dyna_file       => "${file_base}/sudosh.log",
+        stop_processing => $stop_processing
+      }
+    }
+    if $process_tlog_rules {
+      rsyslog::rule::local { '10_default_tlog':
+        rule            => '$programname == \'tlog-rec-session\' or $programname == \'-tlog-rec-session\' or $programname == \'tlog\'',
+        dyna_file       => "${file_base}/tlog.log",
         stop_processing => $stop_processing
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_rsyslog",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet Profile for standard Rsyslog configurations",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/00_rsyslog_spec.rb
+++ b/spec/acceptance/suites/default/00_rsyslog_spec.rb
@@ -3,21 +3,6 @@ require 'spec_helper_acceptance'
 test_name 'simp_rsyslog profile'
 
 describe 'simp_rsyslog' do
-  before(:context) do
-    hosts.each do |host|
-      interfaces = fact_on(host, 'interfaces').strip.split(',')
-      interfaces.delete_if do |x|
-        x =~ /^lo/
-      end
-
-      interfaces.each do |iface|
-        if fact_on(host, "ipaddress_#{iface}").strip.empty?
-          on(host, "ifup #{iface}", :accept_all_exit_codes => true)
-        end
-      end
-    end
-  end
-
   let(:manifest) {
     <<-EOS
       include 'simp_rsyslog'
@@ -74,7 +59,6 @@ describe 'simp_rsyslog' do
         # log messages identified by program name
         on(host, 'logger -t auditd LOCAL_ONLY_AUDITD_LOG')
         on(host, 'logger -t audit LOCAL_ONLY_AUDIT_LOG')
-        on(host, 'logger -p local2.info -t sudosh LOCAL_ONLY_SUDOSH_LOG')
         on(host, 'logger -t sudo LOCAL_ONLY_SUDO_LOG')
         on(host, 'logger -t yum LOCAL_ONLY_YUM_LOG')
         on(host, 'logger -t systemd LOCAL_ONLY_SYSTEMD_LOG')
@@ -91,7 +75,6 @@ describe 'simp_rsyslog' do
 
         [ 'LOCAL_ONLY_AUDITD_LOG',
           'LOCAL_ONLY_AUDIT_LOG',
-          'LOCAL_ONLY_SUDOSH_LOG',  # sudosh module is not installed so ends up in secure log
           'LOCAL_ONLY_SUDO_LOG',
           'LOCAL_ONLY_YUM_LOG',
           'LOCAL_ONLY_SYSTEMD_LOG',

--- a/spec/acceptance/suites/default/05_rsyslog_forward_spec.rb
+++ b/spec/acceptance/suites/default/05_rsyslog_forward_spec.rb
@@ -107,7 +107,8 @@ EOS
             ['-p mail.info -t id1',         'CLIENT_FORWARDED_ANY_MAIL_LOG',     nil,               'maillog'],
             ['-p cron.warning -t cron',     'CLIENT_FORWARDED_CRON_ANY_LOG',     'cron.log',        'cron'],
             ['-p local4.emerg -t id2',      'CLIENT_FORWARDED_ANY_EMERG_LOG',    'emergency.log',   'secure'],
-            ['-p local2.info -t sudosh',    'CLIENT_FORWARDED_SUDOSH_LOG',       'sudosh.log',      'secure'], # local='sudosh.log' when sudosh installed
+            ['-p local2.info -t sudosh',    'CLIENT_FORWARDED_SUDOSH_LOG',       'sudosh.log',      'messages'], # local='sudosh.log' when sutosh module used
+            ['-p local2.info -t tlog',    'CLIENT_FORWARDED_TLOG_LOG',           'tlog.log',        'messages'], # local='tlog.log' when tlog module used
             ['-p local6.err -t httpd',      'CLIENT_FORWARDED_HTTPD_ERR_LOG',    'httpd_error.log', 'secure'], # local='httpd/error_log' when simp_apache is installed
             ['-p local6.warning -t httpd',  'CLIENT_FORWARDED_HTTPD_NO_ERR_LOG', 'httpd.log',       'secure'], # local='httpd/access_log' when simp_apache is installed
             ['-t dhcpd',                    'CLIENT_FORWARDED_DHCPD_LOG',        nil,               'messages'], # local='dhcpd' when dhcp is installed
@@ -160,7 +161,7 @@ EOS
                 expect(result.stdout.strip).to eq("/var/log/#{client_logfile}")
               end
             else
-              # Ensure dropped message (e.g., duplicate auditd messages) 
+              # Ensure dropped message (e.g., duplicate auditd messages)
               # are not logged on the client
               on(client, "grep -Rl '#{message}' /var/log", :acceptable_exit_codes => [1])
             end

--- a/spec/acceptance/suites/default/05_rsyslog_forward_spec.rb
+++ b/spec/acceptance/suites/default/05_rsyslog_forward_spec.rb
@@ -107,7 +107,7 @@ EOS
             ['-p mail.info -t id1',         'CLIENT_FORWARDED_ANY_MAIL_LOG',     nil,               'maillog'],
             ['-p cron.warning -t cron',     'CLIENT_FORWARDED_CRON_ANY_LOG',     'cron.log',        'cron'],
             ['-p local4.emerg -t id2',      'CLIENT_FORWARDED_ANY_EMERG_LOG',    'emergency.log',   'secure'],
-            ['-p local2.info -t sudosh',    'CLIENT_FORWARDED_SUDOSH_LOG',       'sudosh.log',      'messages'], # local='sudosh.log' when sutosh module used
+            ['-p local2.info -t sudosh',    'CLIENT_FORWARDED_SUDOSH_LOG',       'sudosh.log',      'messages'], # local='sudosh.log' when sudosh module used
             ['-p local2.info -t tlog',    'CLIENT_FORWARDED_TLOG_LOG',           'tlog.log',        'messages'], # local='tlog.log' when tlog module used
             ['-p local6.err -t httpd',      'CLIENT_FORWARDED_HTTPD_ERR_LOG',    'httpd_error.log', 'secure'], # local='httpd/error_log' when simp_apache is installed
             ['-p local6.warning -t httpd',  'CLIENT_FORWARDED_HTTPD_NO_ERR_LOG', 'httpd.log',       'secure'], # local='httpd/access_log' when simp_apache is installed

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -13,25 +13,30 @@ describe 'simp_rsyslog' do
       end
 
       let(:program_logs) do
-        [ "($programname == 'sudo')",
-          "($programname == 'sudosh')",
-          "($programname == 'yum')",
+        [
+          "($programname == 'aide')",
           "($programname == 'audispd')",
-          "($programname == 'auditd')",
           "($programname == 'audit')",
-          "($programname == 'systemd')",
+          "($programname == 'auditd')",
           "($programname == 'crond')",
           "($programname == 'snmpd')",
-          "($programname == 'aide')"
+          "($programname == 'sudo')",
+          "($programname == 'sudosh')",
+          "($programname == 'systemd')",
+          "($programname == 'tlog')",
+          "($programname == 'tlog-rec-session')",
+          "($programname == '-tlog-rec-session')",
+          "($programname == 'yum')"
         ]
       end
 
       let(:facility_logs) do
-        [ "prifilt('cron.*')",
-          "prifilt('authpriv.*')",
-          "prifilt('local6.*')",
-          "prifilt('local7.warn')",
+        [
           "prifilt('*.emerg')",
+          "prifilt('authpriv.*')",
+          "prifilt('cron.*')",
+          "prifilt('local6.*')",
+          "prifilt('local7.warn')"
         ]
       end
 
@@ -46,15 +51,16 @@ describe 'simp_rsyslog' do
       end
 
       let (:residual_security_logs) do
-        [ "($programname == 'sudo')",
-          "($programname == 'sudosh')",
+        [
+          "($programname == 'audispd')",
           "($programname == 'audit')",
           "($programname == 'auditd')",
-          "($programname == 'yum')",
-          "($programname == 'systemd')",
           "($programname == 'crond')",
-          "prifilt('local7.warn')",
-          "prifilt('*.emerg')"
+          "($programname == 'sudo')",
+          "($programname == 'systemd')",
+          "($programname == 'yum')",
+          "prifilt('*.emerg')",
+          "prifilt('local7.warn')"
         ].join(' or ')
       end
 
@@ -182,6 +188,7 @@ describe 'simp_rsyslog' do
           it { is_expected.to contain_rsyslog__rule__local('10_00_default_cron') }
           it { is_expected.to contain_rsyslog__rule__local('10_00_default_emerg') }
           it { is_expected.to contain_rsyslog__rule__local('10_default_sudosh') }
+          it { is_expected.to contain_rsyslog__rule__local('10_default_tlog') }
           it { is_expected.to contain_rsyslog__rule__local('10_default_httpd_error') }
           it { is_expected.to contain_rsyslog__rule__local('11_default_httpd') }
           it { is_expected.to contain_rsyslog__rule__local('10_default_dhcpd') }
@@ -204,6 +211,7 @@ describe 'simp_rsyslog' do
           it { is_expected.not_to contain_rsyslog__rule__local('30_default_drop') }
           it { is_expected.to contain_class('logrotate') }
           it { is_expected.to create_logrotate__rule('simp_rsyslog_server_profile').with_log_files(['/var/log/hosts/*/*.log' ]) }
+          it { is_expected.to create_logrotate__rule('simp_rsyslog_server_profile').with_lastaction_restart_logger(true) }
         end
 
         context 'simp_rsyslog class that is a log server with all features disabled' do
@@ -220,6 +228,7 @@ describe 'simp_rsyslog' do
           it { is_expected.not_to contain_rsyslog__rule__local('10_00_default_cron') }
           it { is_expected.not_to contain_rsyslog__rule__local('10_00_default_emerg') }
           it { is_expected.not_to contain_rsyslog__rule__local('10_default_sudosh') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_tlog') }
           it { is_expected.not_to contain_rsyslog__rule__local('10_default_httpd_error') }
           it { is_expected.not_to contain_rsyslog__rule__local('11_default_httpd') }
           it { is_expected.not_to contain_rsyslog__rule__local('10_default_dhcpd') }
@@ -254,6 +263,7 @@ describe 'simp_rsyslog' do
           it { is_expected.not_to contain_rsyslog__rule__local('10_00_default_cron') }
           it { is_expected.not_to contain_rsyslog__rule__local('10_00_default_emerg') }
           it { is_expected.not_to contain_rsyslog__rule__local('10_default_sudosh') }
+          it { is_expected.not_to contain_rsyslog__rule__local('10_default_tlog') }
           it { is_expected.not_to contain_rsyslog__rule__local('10_default_httpd_error') }
           it { is_expected.not_to contain_rsyslog__rule__local('11_default_httpd') }
           it { is_expected.not_to contain_rsyslog__rule__local('10_default_dhcpd') }

--- a/spec/fixtures/hieradata/rsyslog_server_features_disabled.yaml
+++ b/spec/fixtures/hieradata/rsyslog_server_features_disabled.yaml
@@ -1,5 +1,6 @@
 ---
 simp_rsyslog::server::process_sudosh_rules: false
+simp_rsyslog::server::process_tlog_rules: false
 simp_rsyslog::server::process_httpd_rules: false
 simp_rsyslog::server::process_dhcpd_rules: false
 simp_rsyslog::server::process_snmpd_rules: false


### PR DESCRIPTION
* Remove the redundant material for sudosh (if they're not using our
  module, we're not going to worry about splitting out local rules since
  that's mostly arbitrary)
* Add support for tlog since it is our future default replacement for
  sudosh
* Update all tests to cover the new settings

SIMP-5099 #comment Update rsyslog subsystem for tlog