### PR TITLE
(SIMP-5157) StreamDriverPermittedPeers  fixed

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Aug 27 018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> = 0.3.0-0
+- Update it to pass in a value for StreamDriverPermittedPeers.  Default
+  to 'LOGSERVERNAME' which requires rsyslog 7.2.0 or later.
+
 * Thu Jun 14 2018 Nick Miller <nick.miller@onyxpoint.com> - 0.2.1-0
 - Update systemd fixtures and CI assets
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Mon Aug 27 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> = 0.3.0-0
+* Mon Aug 27 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 0.3.0-0
 - Update it to pass in a value for StreamDriverPermittedPeers.  Default
   to 'LOGSERVERNAME' which requires rsyslog 7.2.0 or later.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Mon Aug 27 018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> = 0.3.0-0
+* Mon Aug 27 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> = 0.3.0-0
 - Update it to pass in a value for StreamDriverPermittedPeers.  Default
   to 'LOGSERVERNAME' which requires rsyslog 7.2.0 or later.
 

--- a/manifests/forward.pp
+++ b/manifests/forward.pp
@@ -21,12 +21,26 @@
 #     systems where you want a minimum of log information to be captured
 #     locally.
 #
+# @param permitted_peers
+#   If TLS is being used, StreamDriverPermittedPeers is used to check the certificates.
+#   permitted_peers is used to set this.  In general, certificates will use the FQDN
+#   of the host as the CN in the subject of the certificate.  The default, "LOGSERVERNAME"  assumes that
+#   $::simp_rsyslog::log_servers and  $::simp_rsyslog::failover_log_servers are a list
+#   of FQDNs and that certificates used by the log servers to encrypt traffic use this for the CN.
+#   If this is not the case, then you will need to set this variable appropriately.
+#   Example:  If IP Addresses are used in the two simp_rsyslog settings above and the CN in 
+#   the servers certs are server.my.domain and server2,my.other.domain: 
+#   Set this to "server.my.domain,server2.my.other.domain"
+#   @see https://www.rsyslog.com/doc/v8-stable/configuration/modules/omfwd.html
+#   for more information on how to set this.
+#
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class simp_rsyslog::forward (
-  Integer                  $order           = 99,
-  Enum['tcp','udp','relp'] $dest_type       = 'tcp',
-  Boolean                  $stop_processing = false
+  Integer                  $order            = 99,
+  Enum['tcp','udp','relp'] $dest_type        = 'tcp',
+  Boolean                  $stop_processing  = false,
+  String                   $permitted_peers  = 'LOGSERVERNAME'
 ){
   assert_private()
 
@@ -40,10 +54,11 @@ class simp_rsyslog::forward (
 
 
   rsyslog::rule::remote { "${order}_simp_rsyslog_profile_remote":
-    rule                 => $::simp_rsyslog::security_relevant_logs,
-    dest                 => $::simp_rsyslog::log_servers,
-    failover_log_servers => $::simp_rsyslog::failover_log_servers,
-    dest_type            => $dest_type,
-    stop_processing      => $stop_processing
+    rule                          => $::simp_rsyslog::security_relevant_logs,
+    dest                          => $::simp_rsyslog::log_servers,
+    failover_log_servers          => $::simp_rsyslog::failover_log_servers,
+    dest_type                     => $dest_type,
+    stream_driver_permitted_peers => $permitted_peers,
+    stop_processing               => $stop_processing
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_rsyslog",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet Profile for standard Rsyslog configurations",
   "license": "Apache-2.0",
@@ -18,7 +18,7 @@
     },
     {
       "name": "simp/rsyslog",
-      "version_requirement": ">= 7.1.0 < 8.0.0"
+      "version_requirement": ">= 7.2.0 < 8.0.0"
     },
     {
       "name": "simp/simplib",

--- a/spec/acceptance/suites/two_domains/00_rsyslog_forward_spec.rb
+++ b/spec/acceptance/suites/two_domains/00_rsyslog_forward_spec.rb
@@ -1,0 +1,187 @@
+require 'spec_helper_acceptance'
+
+test_name 'simp_rsyslog profile'
+
+describe 'simp_rsyslog' do
+  before(:context) do
+    hosts.each do |host|
+      interfaces = fact_on(host, 'interfaces').strip.split(',')
+      interfaces.delete_if do |x|
+        x =~ /^lo/
+      end
+
+      interfaces.each do |iface|
+        if fact_on(host, "ipaddress_#{iface}").strip.empty?
+          on(host, "ifup #{iface}", :accept_all_exit_codes => true)
+        end
+      end
+    end
+  end
+
+  let(:manifest) { <<-EOS
+include 'simp_rsyslog'
+EOS
+  }
+  rsyslog_server1 = hosts_with_role(hosts,'rsyslog_server1').first
+  rsyslog_server2 = hosts_with_role(hosts,'rsyslog_server2').first
+  rsyslog_server3 = hosts_with_role(hosts,'rsyslog_server3').first
+  let(:server1_fqdn){fact_on(rsyslog_server1, 'fqdn')}
+  let(:server2_fqdn){fact_on(rsyslog_server2, 'fqdn')}
+  let(:server3_fqdn){fact_on(rsyslog_server3, 'fqdn')}
+  let(:server_hieradata) {
+      <<-EOS
+---
+simp_options::syslog::log_servers:
+  - '#{server1_fqdn}'
+  - '#{server2_fqdn}'
+  - '#{server3_fqdn}'
+
+simp_rsyslog::is_server: true
+simp_rsyslog::forward_logs: false
+rsyslog::tcp_server: true
+rsyslog::tls_tcp_server: true
+rsyslog::pki: true
+rsyslog::app_pki_external_source: '/etc/pki/simp-testing/pki'
+rsyslog::config::tls_input_tcp_server_stream_driver_permitted_peers:
+  - "*.wayout.org"
+  - "*.my.domain"
+EOS
+  }
+  # Set up the servers first so they can both receive from the clients
+  hosts_with_role(hosts, 'rsyslog_server').each do |server|
+
+    it "should configure server #{server} without errors" do
+      set_hieradata_on(server, server_hieradata)
+      apply_manifest_on(server, manifest, :catch_failures => true)
+    end
+
+    it "should configure #{server} idempotently" do
+      apply_manifest_on(server, manifest, :catch_changes => true)
+    end
+  end
+
+  hosts_with_role(hosts, 'rsyslog_server').each do |server|
+    hosts_with_role(hosts, 'rsyslog_client').each do |client|
+      context "#{client} logging to the remote syslog server #{server} with default forwarding" do
+        let(:client_fqdn){ fact_on( client, 'fqdn' ) }
+        let(:client_hieradata) {
+          <<-EOS
+---
+simp_options::syslog::log_servers:
+  - '#{server1_fqdn}'
+  - '#{server2_fqdn}'
+  - '#{server3_fqdn}'
+rsyslog::app_pki_external_source: '/etc/pki/simp-testing/pki'
+simp_rsyslog::forward_logs: true
+rsyslog::pki: true
+rsyslog::enable_tls_logging: true
+         EOS
+        }
+
+        let(:client_log_dir) { "/var/log/hosts/#{client_fqdn}" }
+
+        it "should configure client #{client} without errors" do
+          set_hieradata_on(client, client_hieradata)
+          apply_manifest_on(client, manifest, :catch_failures => true)
+        end
+
+        it "should configure #{client} idempotently" do
+          apply_manifest_on(client, manifest, :catch_changes => true)
+        end
+
+        it "should collect #{client} iptables messages to host-specific, server iptables.log, as well as client iptables.log" do
+          # Set up iptables to disallow icmp requests
+          on(client, 'iptables --list-rules')
+          on(client, 'iptables -N LOG_AND_DROP')
+          on(client, 'iptables -A LOG_AND_DROP -j LOG --log-prefix "IPT:"')
+          on(client, 'iptables -A LOG_AND_DROP -j DROP')
+          on(client, 'iptables -A INPUT -p icmp -m icmp --icmp-type 8 -j LOG_AND_DROP')
+          on(client, 'ping -c 1 `facter ipaddress`', :accept_all_exit_codes => true)
+          result = on(server, "grep -l 'IPT:' #{client_log_dir}/iptables.log")
+          expect(result.stdout.strip).to eq("#{client_log_dir}/iptables.log")
+          result = on(client, "grep -l 'IPT:' /var/log/iptables.log")
+          expect(result.stdout.strip).to eq('/var/log/iptables.log')
+
+          # clean up iptables rules to allow any future tests using the
+          # SIMP iptables module to start with a clean slate
+          on(client, 'iptables --delete LOG_AND_DROP -j LOG --log-prefix "IPT:"')
+          on(client, 'iptables --delete LOG_AND_DROP -j DROP')
+          on(client, 'iptables --delete INPUT -p icmp -m icmp --icmp-type 8 -j LOG_AND_DROP')
+          on(client, 'iptables -X LOG_AND_DROP')
+          on(client, 'iptables --list-rules')
+        end
+
+        it "should collect #{client} messages to host-specific, server logs, as well as client logs" do
+          # Each entry in this array is [log_options, log_message, server_logfile, client_logfile]
+          # server_logfile is the relative log file in the client-specific directory;
+          #   when nil, this means the log is NOT forwarded.
+          # client_logfile is the relative, local log file on the client;
+          #   when nil, this means the log is dropped
+          default_test_array = [
+            ['-p local7.warning -t boot',   'CLIENT_FORWARDED_BOOT_LOG',         'boot.log',        'secure'],
+            ['-p mail.info -t id1',         'CLIENT_FORWARDED_ANY_MAIL_LOG',     nil,               'maillog'],
+            ['-p cron.warning -t cron',     'CLIENT_FORWARDED_CRON_ANY_LOG',     'cron.log',        'cron'],
+            ['-p local4.emerg -t id2',      'CLIENT_FORWARDED_ANY_EMERG_LOG',    'emergency.log',   'secure'],
+            ['-p local2.info -t sudosh',    'CLIENT_FORWARDED_SUDOSH_LOG',       'sudosh.log',      'secure'], # local='sudosh.log' when sudosh installed
+            ['-p local6.err -t httpd',      'CLIENT_FORWARDED_HTTPD_ERR_LOG',    'httpd_error.log', 'secure'], # local='httpd/error_log' when simp_apache is installed
+            ['-p local6.warning -t httpd',  'CLIENT_FORWARDED_HTTPD_NO_ERR_LOG', 'httpd.log',       'secure'], # local='httpd/access_log' when simp_apache is installed
+            ['-t dhcpd',                    'CLIENT_FORWARDED_DHCPD_LOG',        nil,               'messages'], # local='dhcpd' when dhcp is installed
+            ['-p local6.info -t snmpd',     'CLIENT_FORWARDED_SNMPD_LOG',        'snmpd.log',       'secure'], # local='snmpd.log' when snmpd is installed
+            ['-p local6.notice -t aide',    'CLIENT_FORWARDED_AIDE_LOG',         'aide.log',        'secure'], # local='aide/aide.log' when aide is installed
+            ['-p local6.err -t puppet-agent',     'CLIENT_FORWARDED_PUPPET_AGENT_ERR_LOG',     'puppet_agent_error.log', 'puppet-agent-err.log'],
+            ['-p local6.warning -t puppet-agent', 'CLIENT_FORWARDED_PUPPET_AGENT_NO_ERR_LOG',  'puppet_agent.log',       'puppet-agent.log'],
+            ['-p local6.err -t puppetserver',     'CLIENT_FORWARDED_PUPPETSERVER_ERR_LOG',     'puppetserver_error.log', 'puppetserver-err.log'],
+          ['-p local6.warning -t puppetserver', 'CLIENT_FORWARDED_PUPPETSERVER_NO_ERR_LOG',  'puppetserver.log',       'puppetserver.log'],
+          ['-p local5.notice -t audispd', 'CLIENT_FORWARDED_AUDISPD_LOG',      'auditd.log',  nil],  # locally defeated as already in /var/log/audit when real audispd message
+          ['-t slapd_audit',              'CLIENT_FORWARDED_SLAPD_AUDIT_LOG',  nil,          'slapd_audit.log'],
+          ['-p news.crit -t news',        'CLIENT_FORWARDED_NEWS_CRIT_LOG',    nil,          'spooler'], #syslog module FIXME also appears in messages
+          ['-p uucp.crit -t uucp',        'CLIENT_FORWARDED_UUCP_CRIT_LOG',    nil,          'spooler'], #syslog module FIXME also appears in messages, locally
+          ['-t sudo',                     'CLIENT_FORWARDED_SUDO_LOG',         'secure.log', 'secure'],
+          ['-t auditd',                   'CLIENT_FORWARDED_AUDITD_LOG',       'secure.log', 'secure'],
+          ['-t audit',                    'CLIENT_FORWARDED_AUDIT_LOG',        'secure.log', 'secure'],
+          ['-t yum',                      'CLIENT_FORWARDED_YUM_LOG',          'secure.log', 'secure'],
+            ['-t systemd',                  'CLIENT_FORWARDED_SYSTEMD_LOG',      'secure.log', 'secure'],
+            ['-t crond',                    'CLIENT_FORWARDED_CROND_LOG',        'secure.log', 'secure'],
+            ['-p authpriv.warning -t auth', 'CLIENT_FORWARDED_AUTHPRIV_ANY_LOG', 'secure.log', 'secure'],
+            ['-p local6.info -t id3',       'CLIENT_FORWARDED_LOCAL6_ANY_LOG',   'secure.log', 'secure']
+          ]
+
+          # send the messages
+          default_test_array.each do |options,message,logfile|
+            on(client,"logger #{options} #{message}")
+          end
+
+          wait_for_log_message(server, File.join(client_log_dir, default_test_array[-1][2]),
+            default_test_array[-1][1])
+
+          # verify messages are forwarded and persisted, as appropriate
+          default_test_array.each do |options,message,server_logfile,client_logfile|
+            if server_logfile
+              # Ensure message ended up in the intended log.
+              result = on(server, "grep -Rl '#{message}' #{client_log_dir}")
+              expect(result.stdout.strip).to eq("#{client_log_dir}/#{server_logfile}")
+            else
+              # Ensure message is not forwarded.
+              on(server, "grep -Rl '#{message}' #{client_log_dir}", :acceptable_exit_codes => [1])
+            end
+            if client_logfile
+              # Ensure messages are still logged on the client
+              result = on(client, "grep -l '#{message}' /var/log/#{client_logfile}")
+              if (message == 'CLIENT_FORWARDED_NEWS_CRIT_LOG' or
+                  message == 'CLIENT_FORWARDED_UUCP_CRIT_LOG')
+                # logged to /var/log/spooler AND /var/log/messages because of syslog module bug
+                expect(result.stdout.strip).to match(/\/var\/log\/#{client_logfile}/)
+              else
+                expect(result.stdout.strip).to eq("/var/log/#{client_logfile}")
+              end
+            else
+              # Ensure dropped message (e.g., duplicate auditd messages)
+              # are not logged on the client
+              on(client, "grep -Rl '#{message}' /var/log", :acceptable_exit_codes => [1])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/suites/two_domains/nodesets/default.yml
+++ b/spec/acceptance/suites/two_domains/nodesets/default.yml
@@ -1,0 +1,75 @@
+HOSTS:
+  el7server.my.domain:
+    roles:
+      - default
+      - rsyslog_server1
+      - rsyslog_server
+      - el7
+    platform:   el-7-x86_64
+    box:        centos/7
+    hypervisor: vagrant
+    yum_repos:
+      epel:
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
+        gpgkeys:
+          - https://getfedora.org/static/352C64E5.txt
+
+  el7server.wayout.org:
+    roles:
+      - rsyslog_server3
+      - rsyslog_server
+      - el7
+    platform:   el-7-x86_64
+    box:        centos/7
+    hypervisor: vagrant
+    yum_repos:
+      epel:
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
+        gpgkeys:
+          - https://getfedora.org/static/352C64E5.txt
+
+  el7client.my.domain:
+    roles:
+      - rsyslog_client
+      - el7
+    platform:   el-7-x86_64
+    box:        centos/7
+    hypervisor: vagrant
+    yum_repos:
+      epel:
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
+        gpgkeys:
+          - https://getfedora.org/static/352C64E5.txt
+
+  el6server.wayout.org:
+    roles:
+      - rsyslog_server2
+      - rsyslog_server
+      - el6
+    platform:   el-6-x86_64
+    box:        centos/6
+    hypervisor: vagrant
+    yum_repos:
+      epel:
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
+        gpgkeys:
+          - https://getfedora.org/static/0608B895.txt
+
+  el6client.wayout.org:
+    roles:
+      - rsyslog_client
+      - el6
+    platform:   el-6-x86_64
+    box:        centos/6
+    hypervisor: vagrant
+    yum_repos:
+      epel:
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
+        gpgkeys:
+          - https://getfedora.org/static/0608B895.txt
+
+CONFIG:
+  log_level: verbose
+  type:      aio
+  vagrant_memsize: 256
+  # vb_gui: true


### PR DESCRIPTION
  - added permitted_peers parameter so the stream_driver_permitted_peers
    parameters of rsyslog could be set in the call to set up the
    remote rule on the client.
  - default permitted_peers to "LOGSERVERNAME" so the name in the
    log_servers
    array would be used.
  - updated metadata.json to require pupmod-simp-rsyslog 7.2.0 or later
    so the default value "LOGSERVERNAME" would work.
  - The above changes will allow the client to send to remote log
    servers that are in a different domain then itself.  When using TLS
    the FQDN of the remote logserver should be used in the log_server
    array.  If it is not used, be sure to set the permitted_peers
    parameter in hiera.

SIMP-5157 #close