### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.3.1-0
+- Update the upper bound of stdlib to < 6.0.0
+- Update a URL in the README.md
+
 * Wed Oct 17 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 0.3.0-0
 - Updated acceptance test to run rsyslog twice then check for idempotence.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ filesystem.
 
 ### Centralized Logging
 
-While we highly recommend [using ELG](https://simp.readthedocs.io/en/master/user_guide/HOWTO/Central_Log_Collection/Logstash.html) for collecting your logs, we understand that this
+While we highly recommend [using ELG](https://simp.readthedocs.io/en/stable/user_guide/HOWTO/Central_Log_Collection/Logstash.html) for collecting your logs, we understand that this
 is not practical for all situations.
 
 If you wish to collect logs from remote hosts, you can do the following:
@@ -175,7 +175,7 @@ supported operating systems, Puppet versions, and module dependencies.
 
 ## Development
 
-Please read our [Contribution Guide](http://simp.readthedocs.io/en/master/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 If you find any issues, they can be submitted to our
 [JIRA](https://simp-project.atlassian.net).

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_rsyslog",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet Profile for standard Rsyslog configurations",
   "license": "Apache-2.0",
@@ -26,7 +26,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.md

SIMP-6229 #comment pupmod-simp-simp_rsyslog