### PR TITLE
(SIMP-6919) Remove unnecessary EPEL repos in node sets

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -18,9 +18,7 @@ fixtures:
     simpcat: https://github.com/simp/pupmod-simp-simpcat.git
     simplib: https://github.com/simp/pupmod-simp-simplib.git
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
-    systemd:
-      repo: https://github.com/simp/puppet-systemd.git
-      branch: simp-master
+    systemd: https://github.com/simp/puppet-systemd.git
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers.git
   symlinks:
     simp_rsyslog: "#{source_dir}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -184,6 +184,13 @@ pup5.5.10-oel-fips:
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
 
+pup5.5.10-two_domains:
+  <<: *pup_5_5_10
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake spec_clean'
+    - 'bundle exec rake beaker:suites[two_domains]'
+
 pup6:
   <<: *pup_6
   <<: *acceptance_base
@@ -195,3 +202,10 @@ pup6-fips:
   <<: *acceptance_base
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites'
+
+pup6-two_domains:
+  <<: *pup_6
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake spec_clean'
+    - 'bundle exec rake beaker:suites[two_domains]'

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -14,11 +14,6 @@ HOSTS:
     platform:   el-7-x86_64
     box:        centos/7
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/352C64E5.txt
 
   el7-client:
     roles:
@@ -27,11 +22,6 @@ HOSTS:
     platform:   el-7-x86_64
     box:        centos/7
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/352C64E5.txt
 
   el6-server:
     roles:
@@ -40,11 +30,6 @@ HOSTS:
     platform:   el-6-x86_64
     box:        centos/6
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/0608B895.txt
 
   el6-client:
     roles:
@@ -53,11 +38,6 @@ HOSTS:
     platform:   el-6-x86_64
     box:        centos/6
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/0608B895.txt
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -14,11 +14,6 @@ HOSTS:
     platform:   el-7-x86_64
     box:        onyxpoint/oel-7-x86_64
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/352C64E5.txt
 
   el7-client:
     roles:
@@ -27,11 +22,6 @@ HOSTS:
     platform:   el-7-x86_64
     box:        onyxpoint/oel-7-x86_64
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/352C64E5.txt
 
   el6-server:
     roles:
@@ -40,11 +30,6 @@ HOSTS:
     platform:   el-6-x86_64
     box:        onyxpoint/oel-6-x86_64
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/0608B895.txt
 
   el6-client:
     roles:
@@ -53,11 +38,6 @@ HOSTS:
     platform:   el-6-x86_64
     box:        onyxpoint/oel-6-x86_64
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/0608B895.txt
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/suites/two_domains/nodesets/default.yml
+++ b/spec/acceptance/suites/two_domains/nodesets/default.yml
@@ -15,11 +15,6 @@ HOSTS:
     platform:   el-7-x86_64
     box:        centos/7
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/352C64E5.txt
 
   el7client.my.domain:
     roles:
@@ -28,11 +23,6 @@ HOSTS:
     platform:   el-7-x86_64
     box:        centos/7
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/352C64E5.txt
 
   el6server.wayout.org:
     roles:
@@ -42,11 +32,6 @@ HOSTS:
     platform:   el-6-x86_64
     box:        centos/6
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/0608B895.txt
 
   el6client.wayout.org:
     roles:
@@ -55,11 +40,6 @@ HOSTS:
     platform:   el-6-x86_64
     box:        centos/6
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/0608B895.txt
 
 CONFIG:
   log_level: verbose


### PR DESCRIPTION
- Remove EPEL from node sets
- Use correct branch for puppet-systemd in fixtures
- Reinstate two_domains test in GitLab

SIMP-6919 #comment pupmod-simp-simp_rsyslog
SIMP-6949 #comment pupmod-simp-simp_rsyslog
SIMP-6973 #close