### PR TITLE
Remove references to archived SIMP modules

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -148,7 +148,7 @@
 #
 class simp_rsyslog::server (
   Optional[String]                          $server_conf                    = undef,
-  Boolean                                   $process_sudosh_rules           = true,
+  Boolean                                   $process_sudosh_rules           = false,
   Boolean                                   $process_tlog_rules             = true,
   Boolean                                   $process_httpd_rules            = true,
   Boolean                                   $process_dhcpd_rules            = true,


### PR DESCRIPTION
Remove all references to the following archived modules: chkrootkit, hirs_provisioner, incron, network, rkhunter, simp_bolt, simp_ipa, simp_openldap, simp_pki_service, sudosh, tcpwrappers, tpm, xinetd

This includes removal from metadata.json dependencies, .fixtures.yml, Puppetfiles, manifests, spec tests, hiera data, and acceptance tests as applicable.