### PR TITLE
Add clean-state noop acceptance test

### DIFF
--- a/spec/acceptance/suites/default/00_rsyslog_spec.rb
+++ b/spec/acceptance/suites/default/00_rsyslog_spec.rb
@@ -25,6 +25,22 @@ describe 'simp_rsyslog' do
   end
 
   hosts_with_role(hosts, 'rsyslog_client').each do |host|
+    # Exercise noop from a clean (uninstalled) state: on a fresh node the Sicura
+    # console previews the module with `puppet apply --noop`, which must not error
+    # even though nothing simp_rsyslog manages exists yet. Real idempotence is covered
+    # by the applies below. A post-convergence noop check is deliberately omitted:
+    # `puppet apply --noop --detailed-exitcodes` always exits 0, so it could never
+    # fail and would test nothing.
+    context 'in noop mode from a clean state' do
+      before(:context) do
+        on(host, 'puppet resource package rsyslog ensure=absent')
+      end
+
+      it 'applies without errors in noop mode' do
+        apply_manifest_on(host, manifest, catch_failures: true, noop: true)
+      end
+    end
+
     context "local-only logging on #{host.name}" do
       it 'configures the system without errors' do
         set_hieradata_on(host, hieradata)

--- a/spec/acceptance/suites/default/00_rsyslog_spec.rb
+++ b/spec/acceptance/suites/default/00_rsyslog_spec.rb
@@ -31,13 +31,22 @@ describe 'simp_rsyslog' do
     # by the applies below. A post-convergence noop check is deliberately omitted:
     # `puppet apply --noop --detailed-exitcodes` always exits 0, so it could never
     # fail and would test nothing.
+    #
+    # The suite manifest is not reused here: it hardcodes a troubleshooting
+    # iptables::listen rule (so beaker doesn't lock itself out), which pulls in
+    # simp_firewalld, whose Firewalld_service provider is not noop-safe from a
+    # clean state. The console previews the class itself (firewall default-off),
+    # so a bare include is both the representative subject and free of that
+    # unrelated rule. See simp/pupmod-simp-simp_firewalld#106.
     context 'in noop mode from a clean state' do
+      let(:noop_manifest) { "include 'simp_rsyslog'" }
+
       before(:context) do
         on(host, 'puppet resource package rsyslog ensure=absent')
       end
 
       it 'applies without errors in noop mode' do
-        apply_manifest_on(host, manifest, catch_failures: true, noop: true)
+        apply_manifest_on(host, noop_manifest, catch_failures: true, noop: true)
       end
     end
 


### PR DESCRIPTION
Adds an acceptance example that applies the module under `puppet apply --noop` from a fresh, uninstalled node — mirroring the preview the Sicura console runs on a clean host — and asserts it completes without error. It reuses the suite's existing default manifest so the check stays representative of the module's real default, and deliberately omits a post-convergence noop check (`--noop --detailed-exitcodes` always exits 0, so it would test nothing).