### PR TITLE
[puppetsync] Update metadata.json dependency ranges from the Forge

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Aug 24 2026 Steven Pritchard <steve@sicura.us> - 1.0.1
+- [puppetsync] Update metadata.json dependency ranges from the Forge
+
 * Mon Jun 08 2026 Steven Pritchard <steven.pritchard@gmail.com> - 1.0.0
 - Switch `requirements` from `puppet` to `openvox` (>= 8 < 9)
 - Point `issues_url` at GitHub Issues

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_rsyslog",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet Profile for standard Rsyslog configurations",
   "license": "Apache-2.0",
@@ -18,11 +18,11 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 4.9.0 < 6.0.0"
+      "version_requirement": ">= 4.9.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 8.0.0 < 10.0.0"
+      "version_requirement": ">= 8.0.0 < 11.0.0"
     }
   ],
   "simp": {


### PR DESCRIPTION
This patch updates the module's dependency version ranges (including
simp.optional_dependencies) against the Puppet Forge's current
releases: modules that moved are renamed per their superseded_by
chain, and upper version bounds are raised to '< next major' where
the current release fell outside the declared range. Lower bounds
and in-range requirements are untouched. The module version is
bumped (with a matching CHANGELOG entry) so RELENG checks pass.